### PR TITLE
🚩[WIP] feat: 메인페이지 3가지 상태 퍼블리싱 및 line ending 설정 #29

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# 모든 텍스트 파일은 저장소에 LF로 저장, checkout은 OS 따름
+* text=auto eol=lf
+
+# 바이너리 파일은 변환 없음
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.svg binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.otf binary

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "singleQuote": true,
   "printWidth": 80,
   "tabWidth": 2,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "endOfLine": "lf"
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "next": "16.1.7",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "recharts": "^3.8.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
+      recharts:
+        specifier: ^3.8.1
+        version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -569,6 +572,17 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
+  '@reduxjs/toolkit@2.11.2':
+    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -579,6 +593,12 @@ packages:
   '@simple-libs/stream-utils@1.2.0':
     resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
     engines: {node: '>=18'}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -691,6 +711,33 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -710,6 +757,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@typescript-eslint/eslint-plugin@8.57.1':
     resolution: {integrity: sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==}
@@ -1151,6 +1201,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -1182,6 +1276,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -1268,6 +1365,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.45.1:
+    resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1612,6 +1712,12 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.4:
+    resolution: {integrity: sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -1630,6 +1736,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -2149,9 +2259,37 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
+
+  recharts@3.8.1:
+    resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -2168,6 +2306,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2382,6 +2523,9 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
@@ -2467,6 +2611,14 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -3025,6 +3177,18 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.3)(redux@5.0.1))(react@19.2.3)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.4
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.2.3
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.3)(redux@5.0.1)
+
   '@rtsao/scc@1.1.0': {}
 
   '@simple-libs/child-process-utils@1.0.2':
@@ -3032,6 +3196,10 @@ snapshots:
       '@simple-libs/stream-utils': 1.2.0
 
   '@simple-libs/stream-utils@1.2.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -3126,6 +3294,30 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -3143,6 +3335,8 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -3632,6 +3826,44 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-view-buffer@1.0.2:
@@ -3659,6 +3891,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   deep-is@0.1.4: {}
 
@@ -3812,6 +4046,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.45.1: {}
 
   escalade@3.2.0: {}
 
@@ -4229,6 +4465,10 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.4: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -4245,6 +4485,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -4739,7 +4981,42 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-redux@9.2.0(@types/react@19.2.14)(react@19.2.3)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.3
+      use-sync-external-store: 1.6.0(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      redux: 5.0.1
+
   react@19.2.3: {}
+
+  recharts@3.8.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.3)(redux@5.0.1))(react@19.2.3)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.45.1
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-is: 16.13.1
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.3)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.3)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -4764,6 +5041,8 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -5037,6 +5316,8 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinyexec@1.0.4: {}
 
   tinyglobby@0.2.15:
@@ -5160,6 +5441,27 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-sync-external-store@1.6.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,7 @@
 import { QueryProvider } from '@/shared/providers/query-provider';
+import { MockStateProvider } from '@/shared/providers/mock-state-provider';
+import { Header } from '@/widgets/header';
+import { Footer } from '@/widgets/footer';
 import './globals.css';
 
 export const metadata = {
@@ -19,7 +22,11 @@ export default function RootLayout({
           본문 바로가기
         </a>
         <QueryProvider>
-          <main id="main-content">{children}</main>
+          <MockStateProvider>
+            <Header />
+            <main id="main-content">{children}</main>
+            <Footer />
+          </MockStateProvider>
         </QueryProvider>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,37 @@
-export default function Home() {
+'use client';
+
+import { useMockState } from '@/shared/providers/mock-state-provider';
+import { DevStatePanel } from '@/shared/ui/DevStatePanel';
+import { DashboardView } from '@/features/dashboard';
+import {
+  HeroSection,
+  ServiceIntroSection,
+  TrustSection,
+  LandingBottomCta,
+} from '@/features/landing';
+
+function LandingView() {
+  const handleCtaClick = () => {
+    console.warn('[마주봄 목업] "검사 시작" CTA 클릭 → /survey로 이동 예정');
+  };
+
   return (
-    <div className="mx-auto max-w-[1200px] px-4 py-16 text-gray-500 md:px-5 lg:px-6">
-      랜딩 섹션은 다음 작업에서 추가됩니다.
-    </div>
+    <>
+      <HeroSection onCtaClick={handleCtaClick} />
+      <ServiceIntroSection />
+      <TrustSection />
+      <LandingBottomCta onCtaClick={handleCtaClick} />
+    </>
+  );
+}
+
+export default function Home() {
+  const { userState } = useMockState();
+
+  return (
+    <>
+      {userState === 'surveyed' ? <DashboardView /> : <LandingView />}
+      <DevStatePanel />
+    </>
   );
 }

--- a/src/features/dashboard/hooks/useDashboard.ts
+++ b/src/features/dashboard/hooks/useDashboard.ts
@@ -1,0 +1,16 @@
+import {
+  MOCK_USER_PROFILE,
+  MOCK_PERSONALITY_AXES,
+  MOCK_PERSONALITY_SUMMARY,
+  MOCK_MATCHED_JOBS,
+} from '@/shared/utils/mockData';
+
+export function useDashboard() {
+  return {
+    childName: MOCK_USER_PROFILE.name,
+    lastSurveyDate: MOCK_USER_PROFILE.lastSurveyDate,
+    personalityAxes: MOCK_PERSONALITY_AXES,
+    personalitySummary: MOCK_PERSONALITY_SUMMARY,
+    matchedJobs: MOCK_MATCHED_JOBS,
+  };
+}

--- a/src/features/dashboard/hooks/useJobPostings.ts
+++ b/src/features/dashboard/hooks/useJobPostings.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+
+import { MOCK_JOB_POSTINGS } from '@/shared/utils/mockData';
+
+export function useJobPostings() {
+  const [postings, setPostings] = useState(MOCK_JOB_POSTINGS);
+  const [fitFilter, setFitFilter] = useState<string>('전체');
+  const [workTypeFilter, setWorkTypeFilter] = useState<string>('전체');
+  const [locationFilter, setLocationFilter] = useState<string>('전체');
+
+  const filteredPostings = useMemo(() => {
+    return postings.filter((job) => {
+      if (fitFilter !== '전체' && job.fitLevel !== fitFilter) return false;
+      if (workTypeFilter !== '전체' && job.workType !== workTypeFilter)
+        return false;
+      if (locationFilter !== '전체' && !job.location.includes(locationFilter))
+        return false;
+      return true;
+    });
+  }, [postings, fitFilter, workTypeFilter, locationFilter]);
+
+  const toggleBookmark = (id: number) => {
+    setPostings((prev) =>
+      prev.map((job) =>
+        job.id === id ? { ...job, bookmarked: !job.bookmarked } : job,
+      ),
+    );
+    const job = postings.find((j) => j.id === id);
+    if (job) {
+      console.warn(
+        `[마주봄 목업] 북마크 ${job.bookmarked ? '해제' : '추가'}:`,
+        job.title,
+      );
+    }
+  };
+
+  return {
+    postings: filteredPostings,
+    filters: { fitFilter, workTypeFilter, locationFilter },
+    setFitFilter,
+    setWorkTypeFilter,
+    setLocationFilter,
+    toggleBookmark,
+  };
+}

--- a/src/features/dashboard/index.ts
+++ b/src/features/dashboard/index.ts
@@ -1,0 +1,1 @@
+export { DashboardView } from './ui/DashboardView';

--- a/src/features/dashboard/ui/DashboardView.tsx
+++ b/src/features/dashboard/ui/DashboardView.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useDashboard } from '../hooks/useDashboard';
+import { useJobPostings } from '../hooks/useJobPostings';
+import { JobFilterBar } from './JobFilterBar';
+import { JobListSection } from './JobListSection';
+import { MatchedJobsCard } from './MatchedJobsCard';
+import { PersonalitySummaryCard } from './PersonalitySummaryCard';
+
+export function DashboardView() {
+  const { childName, personalityAxes, personalitySummary, matchedJobs } =
+    useDashboard();
+  const {
+    postings,
+    filters,
+    setFitFilter,
+    setWorkTypeFilter,
+    setLocationFilter,
+    toggleBookmark,
+  } = useJobPostings();
+
+  return (
+    <div className="py-10 md:py-16">
+      <div className="mx-auto flex max-w-[1200px] flex-col gap-8 px-4 md:px-5 lg:px-6">
+        <section aria-labelledby="result-summary-heading">
+          <h2 id="result-summary-heading" className="sr-only">
+            검사 결과 요약
+          </h2>
+          <div className="grid gap-5 lg:grid-cols-2">
+            <PersonalitySummaryCard
+              childName={childName}
+              axes={personalityAxes}
+              summary={personalitySummary}
+            />
+            <MatchedJobsCard childName={childName} jobs={matchedJobs} />
+          </div>
+        </section>
+
+        <section aria-labelledby="job-postings-heading">
+          <h2 id="job-postings-heading" className="sr-only">
+            맞춤 채용공고
+          </h2>
+          <div className="flex flex-col gap-5">
+            <JobFilterBar
+              fitFilter={filters.fitFilter}
+              workTypeFilter={filters.workTypeFilter}
+              locationFilter={filters.locationFilter}
+              onFitChange={setFitFilter}
+              onWorkTypeChange={setWorkTypeFilter}
+              onLocationChange={setLocationFilter}
+            />
+            <JobListSection
+              childName={childName}
+              postings={postings}
+              onBookmarkToggle={toggleBookmark}
+            />
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/features/dashboard/ui/JobCard.tsx
+++ b/src/features/dashboard/ui/JobCard.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { Bookmark, BookmarkCheck, MapPin, Calendar, Eye } from 'lucide-react';
+
+import type { JobPosting } from '@/shared/types/job';
+import { FitBadge } from '@/shared/ui/FitBadge';
+
+type JobCardProps = {
+  job: JobPosting;
+  onBookmarkToggle: (id: number) => void;
+};
+
+export function JobCard({ job, onBookmarkToggle }: JobCardProps) {
+  return (
+    <article
+      aria-label={job.title}
+      className="relative flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5 transition-ui hover:border-primary-border"
+    >
+      <header className="flex items-start justify-between gap-3">
+        <div className="flex flex-col gap-1.5">
+          <FitBadge level={job.fitLevel} />
+          <h3 className="text-[0.9375rem] font-semibold leading-[1.5] text-gray-900 line-clamp-1">
+            {job.title}
+          </h3>
+          <p className="text-[0.875rem] text-gray-500">{job.companyName}</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => onBookmarkToggle(job.id)}
+          aria-label={job.bookmarked ? '북마크 해제' : '북마크 추가'}
+          aria-pressed={job.bookmarked}
+          className="transition-ui mt-0.5 shrink-0 rounded-sm p-1 text-gray-400 hover:text-primary"
+        >
+          {job.bookmarked ? (
+            <BookmarkCheck
+              size={20}
+              strokeWidth={1.5}
+              className="text-primary"
+              aria-hidden="true"
+            />
+          ) : (
+            <Bookmark size={20} strokeWidth={1.5} aria-hidden="true" />
+          )}
+        </button>
+      </header>
+
+      <dl className="flex flex-wrap gap-x-4 gap-y-1.5">
+        <div className="flex items-center gap-1">
+          <MapPin
+            size={16}
+            strokeWidth={1.5}
+            className="text-gray-400"
+            aria-hidden="true"
+          />
+          <dt className="sr-only">지역</dt>
+          <dd className="text-[0.8125rem] text-gray-500">{job.location}</dd>
+        </div>
+        <div className="flex items-center gap-1">
+          <dt className="sr-only">근무 형태</dt>
+          <dd className="text-[0.8125rem] text-gray-500">{job.workType}</dd>
+        </div>
+        <div className="flex items-center gap-1">
+          <dt className="sr-only">급여</dt>
+          <dd className="text-[0.8125rem] font-semibold text-gray-700">
+            {job.salary}
+          </dd>
+        </div>
+      </dl>
+
+      <p className="text-[0.8125rem] leading-[1.5] text-primary line-clamp-1">
+        <span className="text-gray-400">매칭 포인트</span>
+        &nbsp;{job.matchPoints}
+      </p>
+
+      <footer className="flex items-center justify-between border-t border-gray-100 pt-3">
+        <div className="flex items-center gap-1 text-gray-400">
+          <Calendar size={14} strokeWidth={1.5} aria-hidden="true" />
+          <span className="text-[0.75rem]">
+            <span className="sr-only">마감일</span>
+            {job.deadline}
+          </span>
+        </div>
+        <div className="flex items-center gap-1 text-gray-400">
+          <Eye size={14} strokeWidth={1.5} aria-hidden="true" />
+          <span className="tabular-nums text-[0.75rem]">
+            <span className="sr-only">조회수</span>
+            {job.views.toLocaleString()}
+          </span>
+        </div>
+      </footer>
+    </article>
+  );
+}

--- a/src/features/dashboard/ui/JobFilterBar.tsx
+++ b/src/features/dashboard/ui/JobFilterBar.tsx
@@ -1,0 +1,99 @@
+import clsx from 'clsx';
+
+type FilterOption = { value: string; label: string };
+
+type FilterGroupProps = {
+  label: string;
+  options: FilterOption[];
+  value: string;
+  onChange: (value: string) => void;
+};
+
+function FilterGroup({ label, options, value, onChange }: FilterGroupProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="shrink-0 text-[0.8125rem] font-semibold text-gray-500">
+        {label}
+      </span>
+      {options.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          onClick={() => onChange(option.value)}
+          aria-pressed={value === option.value}
+          className={clsx(
+            'transition-ui h-8 rounded-md border px-3 text-[0.8125rem] font-semibold',
+            value === option.value
+              ? 'border-primary bg-primary text-white'
+              : 'border-gray-300 bg-white text-gray-700 hover:border-primary-border hover:bg-primary-bg',
+          )}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+const FIT_OPTIONS: FilterOption[] = [
+  { value: '전체', label: '전체' },
+  { value: '잘 맞아요', label: '잘 맞아요' },
+  { value: '도전해볼 수 있어요', label: '도전해볼 수 있어요' },
+];
+
+const WORK_TYPE_OPTIONS: FilterOption[] = [
+  { value: '전체', label: '전체' },
+  { value: '온라인', label: '온라인' },
+  { value: '오프라인', label: '오프라인' },
+];
+
+const LOCATION_OPTIONS: FilterOption[] = [
+  { value: '전체', label: '전체' },
+  { value: '서울', label: '서울' },
+  { value: '경기', label: '경기' },
+];
+
+type JobFilterBarProps = {
+  fitFilter: string;
+  workTypeFilter: string;
+  locationFilter: string;
+  onFitChange: (value: string) => void;
+  onWorkTypeChange: (value: string) => void;
+  onLocationChange: (value: string) => void;
+};
+
+export function JobFilterBar({
+  fitFilter,
+  workTypeFilter,
+  locationFilter,
+  onFitChange,
+  onWorkTypeChange,
+  onLocationChange,
+}: JobFilterBarProps) {
+  return (
+    <div
+      role="group"
+      aria-label="채용공고 필터"
+      className="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4"
+    >
+      <FilterGroup
+        label="적합도"
+        options={FIT_OPTIONS}
+        value={fitFilter}
+        onChange={onFitChange}
+      />
+      <FilterGroup
+        label="근무 형태"
+        options={WORK_TYPE_OPTIONS}
+        value={workTypeFilter}
+        onChange={onWorkTypeChange}
+      />
+      <FilterGroup
+        label="지역"
+        options={LOCATION_OPTIONS}
+        value={locationFilter}
+        onChange={onLocationChange}
+      />
+    </div>
+  );
+}

--- a/src/features/dashboard/ui/JobListSection.tsx
+++ b/src/features/dashboard/ui/JobListSection.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import type { JobPosting } from '@/shared/types/job';
+import { Skeleton } from '@/shared/ui/Skeleton';
+import { JobCard } from './JobCard';
+
+type JobListSectionProps = {
+  childName: string;
+  postings: JobPosting[];
+  onBookmarkToggle: (id: number) => void;
+  isLoading?: boolean;
+};
+
+export function JobListSection({
+  childName,
+  postings,
+  onBookmarkToggle,
+  isLoading = false,
+}: JobListSectionProps) {
+  return (
+    <section aria-labelledby="job-list-heading">
+      <h2
+        id="job-list-heading"
+        className="mb-5 border-l-[3px] border-primary pl-[10px] text-[1rem] font-semibold leading-[1.5] text-gray-900"
+      >
+        {childName}님에게 맞는 채용공고
+      </h2>
+
+      {isLoading ? (
+        <ul
+          aria-busy="true"
+          aria-label="채용공고 로딩 중"
+          className="grid gap-4 md:grid-cols-2"
+        >
+          {Array.from({ length: 4 }).map((_, i) => (
+            <li key={i} className="rounded-lg border border-gray-200 p-5">
+              <Skeleton className="mb-3 h-6 w-16 rounded-sm" />
+              <Skeleton className="mb-2 h-5 w-3/4 rounded-sm" />
+              <Skeleton className="mb-4 h-4 w-1/2 rounded-sm" />
+              <Skeleton className="h-4 w-full rounded-sm" />
+            </li>
+          ))}
+        </ul>
+      ) : postings.length === 0 ? (
+        <div className="flex flex-col items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 py-16 text-center">
+          <p className="text-[0.9375rem] font-semibold text-gray-700">
+            조건에 맞는 채용공고가 없어요
+          </p>
+          <p className="text-[0.875rem] text-gray-400">필터를 조정해 보세요</p>
+        </div>
+      ) : (
+        <ul className="grid gap-4 md:grid-cols-2" aria-label="채용공고 목록">
+          {postings.map((job) => (
+            <li key={job.id}>
+              <JobCard job={job} onBookmarkToggle={onBookmarkToggle} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/features/dashboard/ui/MatchedJobsCard.tsx
+++ b/src/features/dashboard/ui/MatchedJobsCard.tsx
@@ -1,0 +1,41 @@
+import type { MatchedJob } from '@/shared/types/job';
+import { FitBadge } from '@/shared/ui/FitBadge';
+
+type MatchedJobsCardProps = {
+  childName: string;
+  jobs: MatchedJob[];
+};
+
+export function MatchedJobsCard({ childName, jobs }: MatchedJobsCardProps) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-6">
+      <h3 className="mb-6 border-l-[3px] border-primary pl-[10px] text-[1rem] font-semibold leading-[1.5] text-gray-900">
+        {childName}님에게 맞는 직종 TOP 3
+      </h3>
+      <ol className="flex flex-col gap-3" aria-label="매칭 직종 목록">
+        {jobs.map((job, index) => (
+          <li
+            key={job.id}
+            className="flex items-center gap-4 rounded-md border border-gray-200 bg-white px-4 py-3"
+          >
+            <span
+              className="flex h-6 w-6 shrink-0 items-center justify-center rounded-sm bg-gray-100 text-[0.75rem] font-semibold text-gray-500 tabular-nums"
+              aria-label={`${index + 1}위`}
+            >
+              {index + 1}
+            </span>
+            <span className="flex-1 text-[0.9375rem] font-semibold text-gray-900 leading-[1.5]">
+              {job.name}
+            </span>
+            <div className="flex items-center gap-3">
+              <FitBadge level={job.fitLevel} />
+              <span className="tabular-nums text-[0.875rem] font-semibold text-primary">
+                {job.matchRate}%
+              </span>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/src/features/dashboard/ui/PersonalityRadarChart.tsx
+++ b/src/features/dashboard/ui/PersonalityRadarChart.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import {
+  Radar,
+  RadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  ResponsiveContainer,
+} from 'recharts';
+
+import type { PersonalityAxis } from '@/shared/types/job';
+
+type PersonalityRadarChartProps = {
+  data: PersonalityAxis[];
+};
+
+export function PersonalityRadarChart({ data }: PersonalityRadarChartProps) {
+  return (
+    <div className="w-full max-w-[320px]" aria-hidden="true">
+      <ResponsiveContainer width="100%" height={260}>
+        <RadarChart
+          data={data}
+          margin={{ top: 16, right: 24, bottom: 16, left: 24 }}
+        >
+          <PolarGrid stroke="var(--gray-200)" strokeWidth={1} />
+          <PolarAngleAxis
+            dataKey="subject"
+            tick={{
+              fontSize: 13,
+              fill: 'var(--gray-500)',
+              fontWeight: 400,
+            }}
+          />
+          <Radar
+            name="특성"
+            dataKey="value"
+            stroke="var(--primary)"
+            fill="var(--primary)"
+            fillOpacity={0.3}
+            strokeWidth={1.5}
+          />
+        </RadarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/features/dashboard/ui/PersonalitySummaryCard.tsx
+++ b/src/features/dashboard/ui/PersonalitySummaryCard.tsx
@@ -1,0 +1,33 @@
+import type { PersonalityAxis } from '@/shared/types/job';
+import { PersonalityRadarChart } from './PersonalityRadarChart';
+
+type PersonalitySummaryCardProps = {
+  childName: string;
+  axes: PersonalityAxis[];
+  summary: string;
+};
+
+export function PersonalitySummaryCard({
+  childName,
+  axes,
+  summary,
+}: PersonalitySummaryCardProps) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-6">
+      <h3 className="mb-6 border-l-[3px] border-primary pl-[10px] text-[1rem] font-semibold leading-[1.5] text-gray-900">
+        {childName}님의 직업 성향
+      </h3>
+      <div className="flex flex-col items-center gap-6 md:flex-row md:items-start">
+        <PersonalityRadarChart data={axes} />
+        <div className="flex flex-1 flex-col justify-center gap-3">
+          <p className="text-[0.875rem] leading-[1.6] text-gray-500">
+            AI 성향 요약
+          </p>
+          <p className="text-[0.9375rem] leading-[1.6] text-gray-900">
+            &ldquo;{summary}&rdquo;
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/landing/index.ts
+++ b/src/features/landing/index.ts
@@ -1,0 +1,4 @@
+export { HeroSection } from './ui/HeroSection';
+export { ServiceIntroSection } from './ui/ServiceIntroSection';
+export { TrustSection } from './ui/TrustSection';
+export { LandingBottomCta } from './ui/LandingBottomCta';

--- a/src/features/landing/ui/HeroSection.tsx
+++ b/src/features/landing/ui/HeroSection.tsx
@@ -1,0 +1,38 @@
+import { Button } from '@/shared/ui/Button';
+
+type HeroSectionProps = {
+  onCtaClick: () => void;
+};
+
+export function HeroSection({ onCtaClick }: HeroSectionProps) {
+  return (
+    <section
+      aria-labelledby="hero-heading"
+      className="bg-primary-bg py-16 md:py-20 lg:py-24"
+    >
+      <div className="mx-auto max-w-[1200px] px-4 md:px-5 lg:px-6">
+        <div className="flex flex-col items-start gap-6 md:max-w-[640px]">
+          <h1
+            id="hero-heading"
+            className="text-[1.75rem] font-bold leading-[1.35] text-gray-900 md:text-[2rem]"
+          >
+            우리 아이에게 맞는 일,
+            <br />
+            같이 찾아볼까요?
+          </h1>
+          <p className="text-[1rem] leading-[1.6] text-gray-700">
+            자녀의 특성을 입력하면 AI가 적합한 직종과 채용공고를 찾아드려요
+          </p>
+          <div className="flex flex-col items-start gap-3">
+            <Button size="lg" variant="primary" onClick={onCtaClick}>
+              무료로 검사 시작하기
+            </Button>
+            <p className="text-[0.8125rem] text-gray-500">
+              약 3분 소요 · 회원가입 없이 체험 가능
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/landing/ui/LandingBottomCta.tsx
+++ b/src/features/landing/ui/LandingBottomCta.tsx
@@ -1,0 +1,28 @@
+import { Button } from '@/shared/ui/Button';
+
+type LandingBottomCtaProps = {
+  onCtaClick: () => void;
+};
+
+export function LandingBottomCta({ onCtaClick }: LandingBottomCtaProps) {
+  return (
+    <section
+      aria-labelledby="bottom-cta-heading"
+      className="border-t border-gray-200 py-16 md:py-20"
+    >
+      <div className="mx-auto max-w-[1200px] px-4 md:px-5 lg:px-6">
+        <div className="flex flex-col items-start gap-5 md:flex-row md:items-center md:justify-between">
+          <h2
+            id="bottom-cta-heading"
+            className="text-[1.375rem] font-bold leading-[1.4] text-gray-900"
+          >
+            지금 바로 우리 아이 직종 찾기
+          </h2>
+          <Button size="lg" variant="primary" onClick={onCtaClick}>
+            검사 시작하기
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/landing/ui/ServiceIntroSection.tsx
+++ b/src/features/landing/ui/ServiceIntroSection.tsx
@@ -1,0 +1,56 @@
+const SERVICE_ITEMS = [
+  {
+    number: '01',
+    title: '특성 검사',
+    description: '선호 활동, 신체 조건 등 간단한 항목을 편하게 선택해요',
+  },
+  {
+    number: '02',
+    title: 'AI 직종 매칭',
+    description: '공공 데이터 기반으로 잘 맞는 직종을 3단계로 알려드려요',
+  },
+  {
+    number: '03',
+    title: '공고 적합도 판별',
+    description: '채용공고를 넣으면 우리 아이에게 맞는지 분석해드려요',
+  },
+] as const;
+
+export function ServiceIntroSection() {
+  return (
+    <section
+      aria-labelledby="service-intro-heading"
+      className="py-16 md:py-20 lg:py-24"
+    >
+      <div className="mx-auto max-w-[1200px] px-4 md:px-5 lg:px-6">
+        <h2
+          id="service-intro-heading"
+          className="mb-8 text-[1.375rem] font-bold leading-[1.4] text-gray-900 md:mb-10"
+        >
+          이렇게 도와드려요
+        </h2>
+        <ul className="grid gap-4 md:grid-cols-3 md:gap-6">
+          {SERVICE_ITEMS.map((item) => (
+            <li
+              key={item.number}
+              className="rounded-lg border border-gray-200 bg-white p-6"
+            >
+              <span
+                className="mb-4 block text-[0.75rem] font-semibold text-primary"
+                aria-hidden="true"
+              >
+                {item.number}
+              </span>
+              <h3 className="mb-2 text-[1rem] font-semibold leading-[1.5] text-gray-900">
+                {item.title}
+              </h3>
+              <p className="text-[0.875rem] leading-[1.6] text-gray-500">
+                {item.description}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/src/features/landing/ui/TrustSection.tsx
+++ b/src/features/landing/ui/TrustSection.tsx
@@ -1,0 +1,32 @@
+const TRUST_ORGS = [
+  '한국고용정보원',
+  '한국장애인고용공단',
+  '공공데이터포털',
+] as const;
+
+export function TrustSection() {
+  return (
+    <section
+      aria-labelledby="trust-heading"
+      className="border-t border-gray-200 bg-gray-50 py-12 md:py-16"
+    >
+      <div className="mx-auto max-w-[1200px] px-4 md:px-5 lg:px-6">
+        <p
+          id="trust-heading"
+          className="mb-6 text-[0.875rem] font-semibold text-gray-500"
+        >
+          공공 데이터 기반 서비스
+        </p>
+        <ul className="flex flex-wrap gap-3" aria-label="데이터 출처 기관 목록">
+          {TRUST_ORGS.map((org) => (
+            <li key={org}>
+              <span className="inline-flex h-8 items-center rounded-sm border border-gray-200 bg-white px-3 text-[0.8125rem] font-semibold text-gray-700">
+                {org}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/src/shared/providers/mock-state-provider.tsx
+++ b/src/shared/providers/mock-state-provider.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { createContext, useContext, useState, useEffect } from 'react';
+
+import type { UserState } from '@/shared/types/user';
+
+type MockStateContextValue = {
+  userState: UserState;
+  setUserState: (state: UserState) => void;
+};
+
+const MockStateContext = createContext<MockStateContextValue>({
+  userState: 'guest',
+  setUserState: () => {},
+});
+
+export function MockStateProvider({ children }: { children: React.ReactNode }) {
+  const [userState, setUserState] = useState<UserState>('guest');
+
+  useEffect(() => {
+    console.warn('[마주봄 목업] 현재 사용자 상태:', userState);
+    console.warn(
+      '[마주봄 목업] DevPanel에서 상태를 전환하거나 setUserState("guest" | "loggedIn" | "surveyed")로 변경할 수 있습니다.',
+    );
+  }, [userState]);
+
+  return (
+    <MockStateContext.Provider value={{ userState, setUserState }}>
+      {children}
+    </MockStateContext.Provider>
+  );
+}
+
+export function useMockState() {
+  return useContext(MockStateContext);
+}

--- a/src/shared/types/job.ts
+++ b/src/shared/types/job.ts
@@ -1,0 +1,29 @@
+export type FitLevel = '잘 맞아요' | '도전해볼 수 있어요' | '힘들 수 있어요';
+export type WorkType = '온라인' | '오프라인' | '온·오프라인';
+
+export type MatchedJob = {
+  id: number;
+  name: string;
+  matchRate: number;
+  fitLevel: FitLevel;
+};
+
+export type JobPosting = {
+  id: number;
+  companyName: string;
+  title: string;
+  workType: WorkType;
+  location: string;
+  salary: string;
+  deadline: string;
+  views: number;
+  fitLevel: FitLevel;
+  matchPoints: string;
+  bookmarked: boolean;
+};
+
+export type PersonalityAxis = {
+  subject: string;
+  value: number;
+  fullMark: number;
+};

--- a/src/shared/types/user.ts
+++ b/src/shared/types/user.ts
@@ -1,0 +1,6 @@
+export type UserState = 'guest' | 'loggedIn' | 'surveyed';
+
+export type UserProfile = {
+  name: string;
+  lastSurveyDate: string;
+};

--- a/src/shared/ui/DevStatePanel/DevStatePanel.tsx
+++ b/src/shared/ui/DevStatePanel/DevStatePanel.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import clsx from 'clsx';
+
+import { useMockState } from '@/shared/providers/mock-state-provider';
+import type { UserState } from '@/shared/types/user';
+
+const STATES: { value: UserState; label: string; desc: string }[] = [
+  { value: 'guest', label: '비로그인', desc: '랜딩 화면 A' },
+  {
+    value: 'loggedIn',
+    label: '로그인 (검사 전)',
+    desc: '랜딩 화면 A (로그인됨)',
+  },
+  { value: 'surveyed', label: '로그인 + 검사 완료', desc: '대시보드 화면 B' },
+];
+
+export function DevStatePanel() {
+  const { userState, setUserState } = useMockState();
+
+  return (
+    <div
+      role="region"
+      aria-label="개발용 상태 전환 패널"
+      className="fixed bottom-6 right-6 z-[9999] rounded-lg border border-gray-200 bg-white p-4"
+      style={{ boxShadow: '0 4px 16px rgba(0,0,0,0.08)' }}
+    >
+      <p className="mb-3 text-[0.75rem] font-semibold text-gray-500">
+        목업 상태 전환 (개발용)
+      </p>
+      <div className="flex flex-col gap-2">
+        {STATES.map(({ value, label, desc }) => (
+          <button
+            key={value}
+            type="button"
+            onClick={() => setUserState(value)}
+            className={clsx(
+              'transition-ui flex flex-col items-start rounded-md border px-3 py-2 text-left',
+              userState === value
+                ? 'border-primary bg-primary-bg text-primary'
+                : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-100',
+            )}
+          >
+            <span className="text-[0.8125rem] font-semibold leading-tight">
+              {label}
+            </span>
+            <span
+              className={clsx(
+                'mt-0.5 text-[0.75rem]',
+                userState === value ? 'text-primary' : 'text-gray-400',
+              )}
+            >
+              {desc}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/shared/ui/DevStatePanel/index.ts
+++ b/src/shared/ui/DevStatePanel/index.ts
@@ -1,0 +1,1 @@
+export { DevStatePanel } from './DevStatePanel';

--- a/src/shared/ui/FitBadge/FitBadge.tsx
+++ b/src/shared/ui/FitBadge/FitBadge.tsx
@@ -1,0 +1,28 @@
+import clsx from 'clsx';
+
+import type { FitLevel } from '@/shared/types/job';
+
+type FitBadgeProps = {
+  level: FitLevel;
+  className?: string;
+};
+
+const fitBadgeStyles: Record<FitLevel, string> = {
+  '잘 맞아요': 'bg-success-bg text-success',
+  '도전해볼 수 있어요': 'bg-warning-bg text-warning',
+  '힘들 수 있어요': 'bg-error-bg text-error',
+};
+
+export function FitBadge({ level, className }: FitBadgeProps) {
+  return (
+    <span
+      className={clsx(
+        'inline-flex h-6 items-center rounded-sm px-2 text-[0.75rem] font-semibold leading-none',
+        fitBadgeStyles[level],
+        className,
+      )}
+    >
+      {level}
+    </span>
+  );
+}

--- a/src/shared/ui/FitBadge/index.ts
+++ b/src/shared/ui/FitBadge/index.ts
@@ -1,0 +1,1 @@
+export { FitBadge } from './FitBadge';

--- a/src/shared/ui/Skeleton/Skeleton.tsx
+++ b/src/shared/ui/Skeleton/Skeleton.tsx
@@ -1,0 +1,19 @@
+import clsx from 'clsx';
+
+type SkeletonProps = {
+  className?: string;
+  width?: string;
+  height?: string;
+};
+
+export function Skeleton({ className, width, height }: SkeletonProps) {
+  return (
+    <span
+      role="status"
+      aria-busy="true"
+      aria-label="로딩 중"
+      className={clsx('block animate-pulse rounded-sm bg-gray-200', className)}
+      style={{ width, height }}
+    />
+  );
+}

--- a/src/shared/ui/Skeleton/index.ts
+++ b/src/shared/ui/Skeleton/index.ts
@@ -1,0 +1,1 @@
+export { Skeleton } from './Skeleton';

--- a/src/shared/utils/mockData.ts
+++ b/src/shared/utils/mockData.ts
@@ -1,0 +1,114 @@
+import type {
+  MatchedJob,
+  JobPosting,
+  PersonalityAxis,
+} from '@/shared/types/job';
+import type { UserProfile } from '@/shared/types/user';
+
+export const MOCK_USER_PROFILE: UserProfile = {
+  name: '민준',
+  lastSurveyDate: '2026.04.10',
+};
+
+export const MOCK_PERSONALITY_SUMMARY =
+  '반복적이고 조용한 환경에서 손작업에 집중할 때 가장 편안해요';
+
+export const MOCK_PERSONALITY_AXES: PersonalityAxis[] = [
+  { subject: '반복 작업', value: 85, fullMark: 100 },
+  { subject: '대인관계', value: 40, fullMark: 100 },
+  { subject: '신체 활동', value: 60, fullMark: 100 },
+  { subject: '세밀한 손작업', value: 90, fullMark: 100 },
+  { subject: '환경 민감도', value: 70, fullMark: 100 },
+];
+
+export const MOCK_MATCHED_JOBS: MatchedJob[] = [
+  { id: 1, name: '데이터 입력 사무원', matchRate: 92, fitLevel: '잘 맞아요' },
+  { id: 2, name: '조립·포장 작업원', matchRate: 78, fitLevel: '잘 맞아요' },
+  {
+    id: 3,
+    name: '도서관 사서보조',
+    matchRate: 65,
+    fitLevel: '도전해볼 수 있어요',
+  },
+];
+
+export const MOCK_JOB_POSTINGS: JobPosting[] = [
+  {
+    id: 1,
+    companyName: '(주)서울사무직',
+    title: '사무 보조 직원 모집 (장애인 우대)',
+    workType: '오프라인',
+    location: '서울 강남구',
+    salary: '월 220만 원',
+    deadline: '2026.05.01',
+    views: 324,
+    fitLevel: '잘 맞아요',
+    matchPoints: '조용한 사무 환경 · 반복 업무 중심',
+    bookmarked: false,
+  },
+  {
+    id: 2,
+    companyName: '행복나눔재단',
+    title: '장애인 고용 우대 — 포장·분류 작업 보조',
+    workType: '오프라인',
+    location: '서울 마포구',
+    salary: '시급 10,030원',
+    deadline: '2026.04.30',
+    views: 210,
+    fitLevel: '잘 맞아요',
+    matchPoints: '반복 작업 · 조용한 작업 공간',
+    bookmarked: true,
+  },
+  {
+    id: 3,
+    companyName: '디지털도서관',
+    title: '도서 분류·정리 파트타임 스태프',
+    workType: '오프라인',
+    location: '서울 서초구',
+    salary: '시급 11,000원',
+    deadline: '2026.05.15',
+    views: 156,
+    fitLevel: '도전해볼 수 있어요',
+    matchPoints: '정리·분류 업무 · 실내 환경',
+    bookmarked: false,
+  },
+  {
+    id: 4,
+    companyName: '이마트24 물류센터',
+    title: '상품 검수·입고 작업자 채용',
+    workType: '오프라인',
+    location: '경기 성남시',
+    salary: '월 230만 원',
+    deadline: '2026.04.25',
+    views: 445,
+    fitLevel: '도전해볼 수 있어요',
+    matchPoints: '체계적 업무 프로세스 · 팀 작업',
+    bookmarked: false,
+  },
+  {
+    id: 5,
+    companyName: '한국발달장애인훈련센터',
+    title: '바리스타 보조 훈련 연계 채용',
+    workType: '오프라인',
+    location: '서울 노원구',
+    salary: '월 200만 원',
+    deadline: '2026.05.20',
+    views: 289,
+    fitLevel: '잘 맞아요',
+    matchPoints: '손작업 중심 · 반복 루틴 업무',
+    bookmarked: false,
+  },
+  {
+    id: 6,
+    companyName: '스마트팩토리㈜',
+    title: '단순 조립 및 포장 작업원 상시 채용',
+    workType: '오프라인',
+    location: '경기 안산시',
+    salary: '시급 12,000원',
+    deadline: '2026.05.31',
+    views: 512,
+    fitLevel: '잘 맞아요',
+    matchPoints: '반복 작업 · 소규모 팀 환경',
+    bookmarked: false,
+  },
+];

--- a/src/widgets/footer/ui/Footer.tsx
+++ b/src/widgets/footer/ui/Footer.tsx
@@ -1,5 +1,4 @@
-const linkClass =
-  'transition-ui text-[0.875rem] text-gray-700 underline-offset-2 hover:text-gray-900 hover:underline';
+import { FooterLinks } from './FooterLinks';
 
 export function Footer() {
   return (
@@ -7,23 +6,7 @@ export function Footer() {
       <div className="mx-auto max-w-[1200px] px-4 md:px-5 lg:px-6">
         <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
           <p className="text-[1.125rem] font-bold text-gray-900">마주봄</p>
-          <ul className="flex flex-wrap gap-6">
-            <li>
-              <a href="mailto:support@majuboom.kr" className={linkClass}>
-                문의하기
-              </a>
-            </li>
-            <li>
-              <a href="#" className={linkClass}>
-                이용약관
-              </a>
-            </li>
-            <li>
-              <a href="#" className={linkClass}>
-                개인정보처리방침
-              </a>
-            </li>
-          </ul>
+          <FooterLinks />
         </div>
         <small className="mt-8 block text-[0.75rem] text-gray-500">
           © 2026 마주봄. 공공데이터포털 활용 서비스

--- a/src/widgets/footer/ui/FooterLinks.tsx
+++ b/src/widgets/footer/ui/FooterLinks.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useState } from 'react';
+
+import { PolicyModal } from './PolicyModal';
+
+const linkClass =
+  'transition-ui text-[0.875rem] text-gray-700 underline-offset-2 hover:text-gray-900 hover:underline';
+
+export function FooterLinks() {
+  const [openModal, setOpenModal] = useState<'terms' | 'privacy' | null>(null);
+
+  return (
+    <>
+      <ul className="flex flex-wrap gap-6">
+        <li>
+          <a href="mailto:support@majuboom.kr" className={linkClass}>
+            문의하기
+          </a>
+        </li>
+        <li>
+          <button
+            type="button"
+            onClick={() => setOpenModal('terms')}
+            className={linkClass}
+          >
+            이용약관
+          </button>
+        </li>
+        <li>
+          <button
+            type="button"
+            onClick={() => setOpenModal('privacy')}
+            className={linkClass}
+          >
+            개인정보처리방침
+          </button>
+        </li>
+      </ul>
+
+      {openModal && (
+        <PolicyModal type={openModal} onClose={() => setOpenModal(null)} />
+      )}
+    </>
+  );
+}

--- a/src/widgets/footer/ui/PolicyModal.tsx
+++ b/src/widgets/footer/ui/PolicyModal.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { X } from 'lucide-react';
+
+type PolicyContent = {
+  title: string;
+  effectiveDate: string;
+  sections: { heading: string; body: string }[];
+};
+
+const TERMS_CONTENT: PolicyContent = {
+  title: '이용약관',
+  effectiveDate: '2026년 1월 1일',
+  sections: [
+    {
+      heading: '제1조 (목적)',
+      body: '본 약관은 마주봄(이하 "서비스")이 제공하는 AI 직종 탐색 및 채용공고 적합도 판별 서비스의 이용 조건 및 절차에 관한 사항을 규정함을 목적으로 합니다.',
+    },
+    {
+      heading: '제2조 (서비스 이용)',
+      body: '서비스는 장애인 및 장애인 보호자를 위한 직종 탐색 서비스를 제공합니다. 사용자는 자녀의 특성 정보를 입력하여 AI 기반 직종 매칭 결과를 받아볼 수 있습니다.',
+    },
+    {
+      heading: '제3조 (개인정보 처리)',
+      body: '서비스는 입력된 정보를 직종 매칭 목적으로만 사용하며, 제3자에게 제공하지 않습니다. 세부 사항은 개인정보처리방침을 참고하시기 바랍니다.',
+    },
+    {
+      heading: '제4조 (서비스 제한)',
+      body: '서비스는 공공데이터 기반의 정보를 제공하며, 취업 결과를 보장하지 않습니다. AI 매칭 결과는 참고 자료로 활용하시기 바랍니다.',
+    },
+    {
+      heading: '제5조 (면책)',
+      body: '서비스는 천재지변, 시스템 장애 등 불가항력적인 사유로 인한 서비스 중단에 대해 책임을 지지 않습니다.',
+    },
+  ],
+};
+
+const PRIVACY_CONTENT: PolicyContent = {
+  title: '개인정보처리방침',
+  effectiveDate: '2026년 1월 1일',
+  sections: [
+    {
+      heading: '1. 수집하는 개인정보 항목',
+      body: '이름, 나이, 성별, 최종학력, 희망 지역, 장애 유형 및 등급, 신체 조건, 희망 활동 유형 등 자녀 프로필 정보를 수집합니다.',
+    },
+    {
+      heading: '2. 개인정보 수집 목적',
+      body: 'AI 직종 매칭 및 채용공고 적합도 분석 서비스 제공을 위해 개인정보를 수집합니다. 수집된 정보는 목적 달성 후 즉시 파기됩니다.',
+    },
+    {
+      heading: '3. 개인정보 보유 기간',
+      body: '회원 탈퇴 시 또는 서비스 종료 시까지 보유하며, 관계 법령에서 정하는 경우를 제외하고 즉시 파기합니다.',
+    },
+    {
+      heading: '4. 개인정보의 제3자 제공',
+      body: '서비스는 수집된 개인정보를 제3자에게 제공하지 않습니다. 단, 법령에 의한 요구가 있을 경우 관련 기관에 제공할 수 있습니다.',
+    },
+    {
+      heading: '5. 정보주체의 권리',
+      body: '사용자는 언제든지 개인정보 열람, 수정, 삭제를 요청할 수 있으며, 서비스 내 탈퇴 기능을 통해 모든 정보를 삭제할 수 있습니다.',
+    },
+  ],
+};
+
+type PolicyModalProps = {
+  type: 'terms' | 'privacy';
+  onClose: () => void;
+};
+
+export function PolicyModal({ type, onClose }: PolicyModalProps) {
+  const content = type === 'terms' ? TERMS_CONTENT : PRIVACY_CONTENT;
+  const modalRef = useRef<HTMLDivElement>(null);
+  const headingId = `policy-modal-${type}`;
+
+  useEffect(() => {
+    const modal = modalRef.current;
+    if (!modal) return;
+
+    const focusableSelectors =
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+    const focusableElements =
+      modal.querySelectorAll<HTMLElement>(focusableSelectors);
+    const firstFocusable = focusableElements[0];
+    const lastFocusable = focusableElements[focusableElements.length - 1];
+
+    firstFocusable?.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+      if (e.key === 'Tab') {
+        if (e.shiftKey) {
+          if (document.activeElement === firstFocusable) {
+            e.preventDefault();
+            lastFocusable?.focus();
+          }
+        } else {
+          if (document.activeElement === lastFocusable) {
+            e.preventDefault();
+            firstFocusable?.focus();
+          }
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  return (
+    <div
+      role="presentation"
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ backgroundColor: 'rgba(17, 24, 39, 0.5)' }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={headingId}
+        className="flex max-h-[80vh] w-full max-w-[560px] flex-col rounded-lg bg-white"
+        style={{
+          boxShadow: '0 4px 16px rgba(0,0,0,0.08)',
+          animation: 'fadeIn 100ms ease',
+        }}
+      >
+        <div className="flex items-center justify-between border-b border-gray-200 px-6 py-5">
+          <div>
+            <h2
+              id={headingId}
+              className="text-[1rem] font-semibold leading-[1.5] text-gray-900"
+            >
+              {content.title}
+            </h2>
+            <p className="mt-0.5 text-[0.8125rem] text-gray-500">
+              시행일: {content.effectiveDate}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="모달 닫기"
+            className="transition-ui flex h-9 w-9 items-center justify-center rounded-sm text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+          >
+            <X size={20} strokeWidth={1.5} aria-hidden="true" />
+          </button>
+        </div>
+
+        <div className="overflow-y-auto px-6 py-5">
+          <dl className="flex flex-col gap-5">
+            {content.sections.map((section) => (
+              <div key={section.heading}>
+                <dt className="mb-1.5 text-[0.875rem] font-semibold text-gray-900">
+                  {section.heading}
+                </dt>
+                <dd className="text-[0.875rem] leading-[1.6] text-gray-700">
+                  {section.body}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+        @media (prefers-reduced-motion: reduce) {
+          @keyframes fadeIn { from { opacity: 1; } to { opacity: 1; } }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -1,14 +1,19 @@
-import Link from 'next/link';
-import { Menu } from 'lucide-react';
+'use client';
 
+import Link from 'next/link';
+import { User } from 'lucide-react';
+
+import { useMockState } from '@/shared/providers/mock-state-provider';
 import { Button } from '@/shared/ui/Button';
 
 export function Header() {
-  const isAuthed = false;
+  const { userState } = useMockState();
+  const isLoggedIn = userState === 'loggedIn' || userState === 'surveyed';
+  const hasSurvey = userState === 'surveyed';
 
   return (
     <header className="border-b border-gray-200 bg-white">
-      <div className="mx-auto flex h-[56px] max-w-[1200px] items-center justify-between px-4 md:h-[72px] md:px-5 lg:px-6">
+      <div className="mx-auto flex h-14 max-w-[1200px] items-center justify-between px-4 md:h-[72px] md:px-5 lg:px-6">
         <Link
           href="/"
           className="rounded-sm text-[1.125rem] font-bold leading-none text-gray-900"
@@ -16,22 +21,30 @@ export function Header() {
           마주봄
         </Link>
 
-        {!isAuthed && (
-          <>
-            <div className="hidden md:block">
-              <Button variant="secondary" size="md">
-                로그인
-              </Button>
-            </div>
-            <Button
-              variant="ghost"
-              size="icon"
-              aria-label="메뉴 열기"
-              className="md:hidden"
+        {!isLoggedIn && (
+          <Button variant="secondary" size="md">
+            로그인
+          </Button>
+        )}
+
+        {isLoggedIn && (
+          <nav aria-label="사용자 메뉴" className="flex items-center gap-3">
+            {hasSurvey && (
+              <Link
+                href="/survey?mode=edit"
+                className="transition-ui inline-flex h-10 items-center justify-center rounded-md border border-transparent bg-transparent px-4 text-[0.9375rem] font-semibold text-gray-700 hover:bg-gray-100"
+              >
+                다시 검사하기
+              </Link>
+            )}
+            <Link
+              href="/profile"
+              aria-label="프로필 페이지로 이동"
+              className="transition-ui flex h-9 w-9 items-center justify-center rounded-sm border border-gray-200 bg-gray-50 text-gray-700 hover:bg-gray-100"
             >
-              <Menu size={24} strokeWidth={1.5} aria-hidden="true" />
-            </Button>
-          </>
+              <User size={20} strokeWidth={1.5} aria-hidden="true" />
+            </Link>
+          </nav>
         )}
       </div>
     </header>


### PR DESCRIPTION
## 개요
메인페이지(/)의 3가지 사용자 상태(비로그인 / 로그인 + 검사 전 / 검사 완료)를 목업 데이터 기반으로 퍼블리싱하고, Windows 협업자를 위한 line ending 설정을 추가했습니다.

## 주요 변경 사항

### 화면 A — 랜딩 (비로그인 / 로그인 + 검사 전)
- `HeroSection` — 메인 카피 + CTA 버튼
- `ServiceIntroSection` — 서비스 소개 3항목 카드
- `TrustSection` — 공공기관 신뢰 요소
- `LandingBottomCta` — 하단 CTA 반복

### 화면 B — 대시보드 (로그인 + 검사 완료)
- `PersonalitySummaryCard` — recharts 레이더 차트 + AI 성향 요약
- `MatchedJobsCard` — 매칭 직종 TOP 3 (적합도 뱃지 + 매칭률)
- `JobFilterBar` — 적합도 / 근무형태 / 지역 필터
- `JobCard` — 공고 카드 (북마크 토글)
- `JobListSection` — 공고 목록 + 빈 상태 + 스켈레톤

### 공통 컴포넌트
- `Header` — 3가지 상태별 GNB (useMockState 연동)
- `Footer` + `PolicyModal` — 이용약관 / 개인정보처리방침 모달 (포커스 트랩 + ESC)
- `DevStatePanel` — 우측 하단 고정 상태 전환 패널 (개발 전용)
- `FitBadge`, `Skeleton` — 공유 UI 컴포넌트 신규 추가

### 기타
- `.gitattributes` 추가 — `eol=lf` 강제로 Windows CRLF 문제 해결
- `.prettierrc` — `endOfLine: lf` 추가

Closes #29