### PR TITLE
fix: 메인페이지 다크모드 대비·접근성 개선 #40

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,6 +8,7 @@
 :root {
   /* Primary */
   --primary:          #4166E7;
+  --primary-on-dark:  #4166E7;
   --primary-hover:    #3454D1;
   --primary-pressed:  #2A45B8;
   --primary-bg:       #FAFDFF;
@@ -24,7 +25,8 @@
   --gray-200: #E5E7EB;
   --gray-100: #F3F4F6;
   --gray-50:  #F9FAFB;
-  --white:    #FFFFFF;
+  --white:        #FFFFFF;
+  --static-white: #FFFFFF;
 
   /* Semantic */
   --success:     #1E7E34;
@@ -42,6 +44,9 @@
   --surface: #F9FAFB;
   --border:  #E5E7EB;
   --text:    #111827;
+
+  /* Hero */
+  --hero-bg: #E8F0FE;
 }
 
 /* 라이트 모드 명시 */
@@ -68,10 +73,13 @@
     --gray-100: #1F2937;
     --gray-50:  #111827;
 
+    --primary-on-dark:   #7B9CF5;
     --primary-bg:        #0F1A38;
     --primary-tag:       #0F1A38;
     --primary-bg-strong: #1A2A50;
     --primary-border:    #2A3F7A;
+
+    --hero-bg: #060D1E;
   }
 }
 
@@ -93,10 +101,13 @@
   --gray-100: #1F2937;
   --gray-50:  #111827;
 
+  --primary-on-dark:   #7B9CF5;
   --primary-bg:        #0F1A38;
   --primary-tag:       #0F1A38;
   --primary-bg-strong: #1A2A50;
   --primary-border:    #2A3F7A;
+
+  --hero-bg: #060D1E;
 }
 
 /* prefers-reduced-motion */
@@ -115,6 +126,7 @@
 
   /* Primary colors */
   --color-primary:           var(--primary);
+  --color-primary-on-dark:   var(--primary-on-dark);
   --color-primary-hover:     var(--primary-hover);
   --color-primary-pressed:   var(--primary-pressed);
   --color-primary-bg:        var(--primary-bg);
@@ -131,7 +143,8 @@
   --color-gray-200: var(--gray-200);
   --color-gray-100: var(--gray-100);
   --color-gray-50:  var(--gray-50);
-  --color-white:    var(--white);
+  --color-white:        var(--white);
+  --color-static-white: var(--static-white);
 
   /* Semantic colors */
   --color-success:    var(--success);
@@ -149,6 +162,9 @@
   --color-surface: var(--surface);
   --color-border:  var(--border);
   --color-text:    var(--text);
+
+  /* Hero */
+  --color-hero-bg: var(--hero-bg);
 
   /* Border radius — 4 / 6 / 8 만 사용 */
   --radius-sm: 4px;

--- a/src/features/landing/ui/HeroSection.tsx
+++ b/src/features/landing/ui/HeroSection.tsx
@@ -8,7 +8,7 @@ export function HeroSection({ onCtaClick }: HeroSectionProps) {
   return (
     <section
       aria-labelledby="hero-heading"
-      className="bg-primary-bg py-16 md:py-20 lg:py-24"
+      className="bg-hero-bg py-16 md:py-20 lg:py-24"
     >
       <div className="mx-auto max-w-[1200px] px-4 md:px-5 lg:px-6">
         <div className="flex flex-col items-start gap-6 md:max-w-[640px]">

--- a/src/shared/ui/Button/Button.tsx
+++ b/src/shared/ui/Button/Button.tsx
@@ -19,18 +19,19 @@ const sizeClass: Record<ButtonSize, string> = {
 
 const variantClass: Record<ButtonVariant, string> = {
   primary:
-    'border border-transparent bg-primary text-white ' +
+    'border border-transparent bg-primary text-static-white ' +
     'hover:bg-primary-hover active:bg-primary-pressed ' +
     'disabled:bg-gray-200 disabled:text-gray-400',
   secondary:
-    'border border-primary bg-white text-primary ' +
+    'border border-primary-on-dark bg-white text-primary-on-dark ' +
     'hover:bg-primary-bg ' +
     'disabled:border-gray-200 disabled:bg-white disabled:text-gray-400',
   ghost:
     'border border-transparent bg-transparent text-gray-700 ' +
     'hover:bg-gray-100',
   destructive:
-    'border border-transparent bg-error text-white ' + 'hover:bg-error-hover',
+    'border border-transparent bg-error text-static-white ' +
+    'hover:bg-error-hover',
 };
 
 export function Button({

--- a/src/widgets/footer/ui/FooterLinks.tsx
+++ b/src/widgets/footer/ui/FooterLinks.tsx
@@ -14,11 +14,6 @@ export function FooterLinks() {
     <>
       <ul className="flex flex-wrap gap-6">
         <li>
-          <a href="mailto:support@majuboom.kr" className={linkClass}>
-            문의하기
-          </a>
-        </li>
-        <li>
           <button
             type="button"
             onClick={() => setOpenModal('terms')}

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -11,7 +11,7 @@ export function Header() {
   const isLoggedIn = userState === 'loggedIn' || userState === 'surveyed';
 
   return (
-    <header className="border-b border-gray-200 bg-white">
+    <header className="border-b border-gray-200 bg-surface">
       <div className="mx-auto flex h-14 max-w-[1200px] items-center justify-between px-4 md:h-[72px] md:px-5 lg:px-6">
         <Link
           href="/"


### PR DESCRIPTION
## 개요
메인페이지의 다크모드 대비 문제를 수정하고 WCAG AA 기준을 충족하도록 버튼 접근성을 개선했습니다.

## 주요 변경 사항
- **Footer** `문의하기` 버튼 제거
- **GNB** `bg-white` → `bg-surface` 교체 (다크모드: `#1F2937` → `#111827`)
- **HeroSection** 전용 `--hero-bg` 토큰 추가 (라이트: `#E8F0FE`, 다크: `#060D1E`)
- **Button primary** `text-white` → `text-static-white` (다크모드에서도 항상 흰색 텍스트)
- **Button secondary** `text-primary` → `text-primary-on-dark`, `--primary-on-dark` 토큰 추가 (다크모드 대비 **5.1:1**, WCAG AA 충족)

Closes #40