### PR TITLE
🚩feat: add Input/Checkbox/Radio components with shadcn/cva pattern #42

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,10 @@
 | Framework       | Next.js 16 App Router            |
 | Language        | TypeScript (strict)              |
 | Styling         | TailwindCSS v4                   |
+| Component Base  | shadcn/ui 패턴 (cva + cn)        |
 | Data Fetching   | TanStack Query v5                |
 | Global State    | React Context / useState         |
+| Form            | react-hook-form + @hookform/resolvers |
 | Validation      | Zod v4                           |
 | Chart           | Recharts                         |
 | DB              | Supabase (PostgreSQL + pgvector) |
@@ -103,7 +105,6 @@ src/
 
 ## 6. 절대 금지 사항
 
-- `react-hook-form` 사용 금지 — 폼 상태는 `useState`
 - `@supabase/supabase-js` 설치 금지 — raw fetch만 사용
 - default export 금지 (`src/app/` 라우트 파일 제외)
 - 레이어 경계 역방향 참조 금지 (`shared`가 `features`를 import하는 것 등)
@@ -196,11 +197,10 @@ export const useBookmarkToggle = () => useMutation(...);
 
 ## 10. State Management
 
-<!-- TODO: 유저가 직접 작성 -->
-
 - 서버 상태: TanStack Query
 - UI/전역 상태: React Context
-- 폼 상태: useState
+- 폼 상태: react-hook-form (비제어)
+- 단순 로컬 UI 상태: useState
 
 ---
 
@@ -213,6 +213,56 @@ export const useBookmarkToggle = () => useMutation(...);
 3. CSS 변수 토큰만 사용한다 — 색상 하드코딩 절대 금지
 4. 아이콘은 `lucide-react`만 사용, 사이즈 16 / 20 / 24만 허용
 5. `forwardRef` 사용 금지 — React 19 방식으로 `ref`를 일반 prop으로 받는다
+
+### 컴포넌트 작성 패턴 (shadcn/ui 방식)
+
+모든 `shared/ui` 컴포넌트는 아래 패턴을 따른다.
+
+```ts
+// 1. cva로 variant 정의
+const componentVariants = cva('base-classes', {
+  variants: { variant: { ... }, size: { ... } },
+  defaultVariants: { variant: 'default', size: 'md' },
+});
+
+// 2. cn 유틸로 클래스 병합
+import { cn } from '@/shared/utils/cn';
+
+// 3. VariantProps 타입 합성
+type Props = HTMLAttributes<HTMLElement> & VariantProps<typeof componentVariants> & {
+  ref?: Ref<HTMLElement>;
+};
+
+// 4. 비제어 — 모든 네이티브 HTML 속성 그대로 전달
+export function Component({ variant, size, className, ref, ...props }: Props) {
+  return <element ref={ref} {...props} className={cn(componentVariants({ variant, size }), className)} />;
+}
+```
+
+### 폼 컴포넌트와 react-hook-form
+
+- `shared/ui` 폼 컴포넌트(Input, Checkbox, Radio)는 비제어로 작성 — `ref` prop 그대로 전달
+- 폼 로직은 `features/[x]/hooks/use[Feature]Form.ts`에서 `react-hook-form` 사용
+- Zod 스키마는 `features/[x]/utils/schema.ts`에 정의 후 `@hookform/resolvers/zod`로 연결
+
+```ts
+// features/survey/hooks/useSurveyForm.ts
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { SurveySchema } from '../utils/schema';
+
+export function useSurveyForm() {
+  const { register, handleSubmit, formState: { errors } } = useForm({
+    resolver: zodResolver(SurveySchema),
+  });
+  return { register, handleSubmit, errors };
+}
+
+// features/survey/ui/SurveyForm.tsx
+const { register, handleSubmit, errors } = useSurveyForm();
+<Input {...register('name')} error={errors.name?.message} label="이름" required />
+<Checkbox {...register('agree')} error={errors.agree?.message} label="동의합니다" />
+```
 
 ---
 

--- a/docs/UI_guide.md
+++ b/docs/UI_guide.md
@@ -159,6 +159,26 @@ Pretendard, -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Noto Sans
 | Ghost | bg transparent / text `--gray-700` | bg `--gray-100` | — | — | — |
 | Destructive | bg `--error` / text white | bg `#A81818` | — | — | — |
 
+### 컴포넌트 작성 기반 (shadcn/ui 패턴)
+
+모든 `shared/ui` 컴포넌트는 아래 3가지 원칙을 따른다.
+
+1. **cva (class-variance-authority)** — variant / size 분기
+2. **cn 유틸** (`@/shared/utils/cn`) — clsx + tailwind-merge 병합
+3. **비제어 (uncontrolled)** — `ref`를 일반 prop으로 받아 네이티브 요소에 전달
+
+react-hook-form `register()`가 반환하는 `{ ref, name, onChange, onBlur }`를 스프레드하면
+별도 래퍼 없이 즉시 연결된다.
+
+```ts
+// 사용 예
+<Input {...register('email')} error={errors.email?.message} label="이메일" required />
+<Checkbox {...register('agree')} error={errors.agree?.message} label="약관 동의" />
+<Radio {...register('gender')} value="male" label="남성" />
+```
+
+---
+
 ### 입력 필드 (Input / Select / Textarea)
 - 높이: Large `48px` / Medium `40px`
 - border: `1px solid --gray-300`
@@ -170,6 +190,30 @@ Pretendard, -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Noto Sans
 - disabled: bg `--gray-100` / text `--gray-400`
 - 라벨: 필드 위 `14px / 600 / --gray-900`, margin-bottom `8px`
 - 필수 표시: 라벨 옆 `*` 색상 `--error`, `aria-required="true"`
+
+### 체크박스 (Checkbox)
+
+- 컨트롤 크기: `18×18px` / radius: `4px` (`--radius-sm`)
+- 비활성: border `1px solid --gray-300` / bg `--white`
+- 활성(checked): bg `--primary` / border `--primary` / 체크마크 white
+- 체크마크: CSS border 트릭 (rotate 45deg, border-right + border-bottom)
+- focus-visible: outline `2px solid --primary` / offset `2px`
+- disabled: bg `--gray-100` / border `--gray-300` / text `--gray-400`
+- error: border `--error` / checked 시 bg `--error`
+- 에러 메시지: `13px / --error`, `aria-live="polite"`
+- 구현: 네이티브 `<input type="checkbox">` sr-only + 시각적 span — `group-has-[:checked]` 패턴
+- 라벨: 체크박스 우측 `14px / 400 / --gray-900`, gap `8px`
+
+### 라디오 (Radio / RadioGroup)
+
+- 컨트롤 크기: `18×18px` / radius: `50%` (`rounded-full`)
+- 비활성: border `1px solid --gray-300` / bg `--white`
+- 활성(checked): border `--primary` / 내부 dot `8×8px bg --primary`
+- focus-visible: outline `2px solid --primary` / offset `2px`
+- disabled: bg `--gray-100` / border `--gray-300` / dot bg `--gray-400`
+- 구현: 네이티브 `<input type="radio">` sr-only + 시각적 span — `group-has-[:checked]` 패턴
+- 라벨: 라디오 우측 `14px / 400 / --gray-900`, gap `8px`
+- RadioGroup: `<fieldset>` + `<legend>` 사용, 에러는 `aria-live="polite"`
 
 ### Pill 선택 버튼
 - 높이: `40px` / 좌우 padding: `16px` / radius: `6px`

--- a/package.json
+++ b/package.json
@@ -20,14 +20,18 @@
   },
   "dependencies": {
     "@fontsource/pretendard": "^5.2.5",
+    "@hookform/resolvers": "^5.2.2",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-query-devtools": "^5.91.3",
+    "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.8.0",
     "next": "16.1.7",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "react-hook-form": "^7.72.1",
     "recharts": "^3.8.1",
+    "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,18 @@ importers:
       '@fontsource/pretendard':
         specifier: ^5.2.5
         version: 5.2.5
+      '@hookform/resolvers':
+        specifier: ^5.2.2
+        version: 5.2.2(react-hook-form@7.72.1(react@19.2.3))
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.90.21(react@19.2.3)
       '@tanstack/react-query-devtools':
         specifier: ^5.91.3
         version: 5.91.3(@tanstack/react-query@5.90.21(react@19.2.3))(react@19.2.3)
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -32,9 +38,15 @@ importers:
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
+      react-hook-form:
+        specifier: ^7.72.1
+        version: 7.72.1(react@19.2.3)
       recharts:
         specifier: ^3.8.1
         version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1)
+      tailwind-merge:
+        specifier: ^3.5.0
+        version: 3.5.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -325,6 +337,11 @@ packages:
 
   '@fontsource/pretendard@5.2.5':
     resolution: {integrity: sha512-UAj3l+Exfx6Sq5hySbhTQhNzkZnhzBxQdHySmjo2lifXyXpMAHv7GD7hAQTLgZfBd1WixJJkmynfJbOp+TAckg==}
+
+  '@hookform/resolvers@5.2.2':
+    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1121,6 +1138,9 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
@@ -2256,6 +2276,12 @@ packages:
     peerDependencies:
       react: ^19.2.3
 
+  react-hook-form@7.72.1:
+    resolution: {integrity: sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -2515,6 +2541,9 @@ packages:
   synckit@0.11.12:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
   tailwindcss@4.2.1:
     resolution: {integrity: sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==}
@@ -2996,6 +3025,11 @@ snapshots:
       levn: 0.4.1
 
   '@fontsource/pretendard@5.2.5': {}
+
+  '@hookform/resolvers@5.2.2(react-hook-form@7.72.1(react@19.2.3))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.72.1(react@19.2.3)
 
   '@humanfs/core@0.19.1': {}
 
@@ -3750,6 +3784,10 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
 
   cli-cursor@5.0.0:
     dependencies:
@@ -4979,6 +5017,10 @@ snapshots:
       react: 19.2.3
       scheduler: 0.27.0
 
+  react-hook-form@7.72.1(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+
   react-is@16.13.1: {}
 
   react-redux@9.2.0(@types/react@19.2.14)(react@19.2.3)(redux@5.0.1):
@@ -5311,6 +5353,8 @@ snapshots:
   synckit@0.11.12:
     dependencies:
       '@pkgr/core': 0.2.9
+
+  tailwind-merge@3.5.0: {}
 
   tailwindcss@4.2.1: {}
 

--- a/src/shared/ui/Button/Button.tsx
+++ b/src/shared/ui/Button/Button.tsx
@@ -1,41 +1,51 @@
-import clsx from 'clsx';
+import { cva, type VariantProps } from 'class-variance-authority';
 import type { ButtonHTMLAttributes, Ref } from 'react';
+import { cn } from '@/shared/utils/cn';
 
-type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'destructive';
-type ButtonSize = 'lg' | 'md' | 'sm' | 'icon';
+const buttonVariants = cva(
+  'transition-ui inline-flex cursor-pointer items-center justify-center gap-2 rounded-md text-[0.9375rem] font-semibold leading-none disabled:cursor-not-allowed',
+  {
+    variants: {
+      variant: {
+        primary:
+          'border border-transparent bg-primary text-white ' +
+          'hover:bg-primary-hover active:bg-primary-pressed ' +
+          'disabled:bg-gray-200 disabled:text-gray-400',
+        secondary:
+          'border border-primary bg-white text-primary ' +
+          'hover:bg-primary-bg ' +
+          'disabled:border-gray-200 disabled:bg-white disabled:text-gray-400',
+        ghost:
+          'border border-transparent bg-transparent text-gray-700 ' +
+          'hover:bg-gray-100',
+        destructive:
+          'border border-transparent bg-error text-white ' +
+          'hover:bg-error-hover',
+      },
+      size: {
+        lg: 'h-12 px-5',
+        md: 'h-10 px-4',
+        sm: 'h-8 px-3',
+        icon: 'h-11 w-11',
+      },
+    },
+    defaultVariants: {
+      variant: 'primary',
+      size: 'md',
+    },
+  },
+);
 
-type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
-  variant?: ButtonVariant;
-  size?: ButtonSize;
-  ref?: Ref<HTMLButtonElement>;
-};
+export { buttonVariants };
 
-const sizeClass: Record<ButtonSize, string> = {
-  lg: 'h-12 px-5',
-  md: 'h-10 px-4',
-  sm: 'h-8 px-3',
-  icon: 'h-11 w-11',
-};
-
-const variantClass: Record<ButtonVariant, string> = {
-  primary:
-    'border border-transparent bg-primary text-white ' +
-    'hover:bg-primary-hover active:bg-primary-pressed ' +
-    'disabled:bg-gray-200 disabled:text-gray-400',
-  secondary:
-    'border border-primary bg-white text-primary ' +
-    'hover:bg-primary-bg ' +
-    'disabled:border-gray-200 disabled:bg-white disabled:text-gray-400',
-  ghost:
-    'border border-transparent bg-transparent text-gray-700 ' +
-    'hover:bg-gray-100',
-  destructive:
-    'border border-transparent bg-error text-white ' + 'hover:bg-error-hover',
-};
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
+  VariantProps<typeof buttonVariants> & {
+    ref?: Ref<HTMLButtonElement>;
+  };
 
 export function Button({
-  variant = 'primary',
-  size = 'md',
+  variant,
+  size,
   type = 'button',
   disabled,
   className,
@@ -49,13 +59,7 @@ export function Button({
       disabled={disabled}
       aria-disabled={disabled || undefined}
       {...props}
-      className={clsx(
-        'transition-ui inline-flex cursor-pointer items-center justify-center gap-2 rounded-md text-[0.9375rem] font-semibold leading-none',
-        'disabled:cursor-not-allowed',
-        sizeClass[size],
-        variantClass[variant],
-        className,
-      )}
+      className={cn(buttonVariants({ variant, size }), className)}
     />
   );
 }

--- a/src/shared/ui/Checkbox/Checkbox.tsx
+++ b/src/shared/ui/Checkbox/Checkbox.tsx
@@ -1,0 +1,85 @@
+import type { InputHTMLAttributes, Ref } from 'react';
+import { cn } from '@/shared/utils/cn';
+
+type CheckboxProps = Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'type' | 'size'
+> & {
+  label?: string;
+  error?: string;
+  ref?: Ref<HTMLInputElement>;
+};
+
+export function Checkbox({
+  label,
+  error,
+  className,
+  id,
+  ref,
+  ...props
+}: CheckboxProps) {
+  const inputId =
+    id ??
+    (label
+      ? `checkbox-${label.replace(/\s+/g, '-').toLowerCase()}`
+      : undefined);
+  const errorId = error ? `${inputId}-error` : undefined;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label
+        htmlFor={inputId}
+        className="group inline-flex cursor-pointer items-center gap-2 has-[:disabled]:cursor-not-allowed"
+      >
+        {/* 시각적 체크박스 */}
+        <span
+          aria-hidden="true"
+          className={cn(
+            'relative flex h-[1.125rem] w-[1.125rem] shrink-0 items-center justify-center rounded-sm border transition-ui',
+            'border-gray-300 bg-white',
+            'group-has-[:checked]:border-primary group-has-[:checked]:bg-primary',
+            'group-has-[:focus-visible]:outline group-has-[:focus-visible]:outline-2 group-has-[:focus-visible]:outline-primary group-has-[:focus-visible]:[outline-offset:2px]',
+            'group-has-[:disabled]:border-gray-300 group-has-[:disabled]:bg-gray-100',
+            error &&
+              'border-error group-has-[:checked]:border-error group-has-[:checked]:bg-error',
+            className,
+          )}
+        >
+          {/* 체크 마크 (CSS border 트릭) */}
+          <span
+            className="hidden h-2.5 w-1.5 -translate-y-px rotate-45 border-b-2 border-r-2 border-white group-has-[:checked]:block"
+            style={{ borderColor: 'white' }}
+          />
+        </span>
+
+        {/* 실제 input — sr-only로 접근성 유지, ref 전달 */}
+        <input
+          type="checkbox"
+          id={inputId}
+          ref={ref}
+          aria-describedby={errorId}
+          aria-invalid={error ? true : undefined}
+          className="sr-only"
+          {...props}
+        />
+
+        {label && (
+          <span className="text-[0.875rem] font-normal text-gray-900 group-has-[:disabled]:text-gray-400">
+            {label}
+          </span>
+        )}
+      </label>
+
+      {error && (
+        <p
+          id={errorId}
+          role="alert"
+          aria-live="polite"
+          className="text-[0.8125rem] text-error"
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/shared/ui/Checkbox/index.ts
+++ b/src/shared/ui/Checkbox/index.ts
@@ -1,0 +1,1 @@
+export { Checkbox } from './Checkbox';

--- a/src/shared/ui/Input/Input.tsx
+++ b/src/shared/ui/Input/Input.tsx
@@ -1,0 +1,103 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import type { InputHTMLAttributes, Ref } from 'react';
+import { cn } from '@/shared/utils/cn';
+
+const inputVariants = cva(
+  [
+    'w-full rounded-md border bg-white px-4',
+    'text-[0.9375rem] font-normal text-gray-900 placeholder:text-gray-400',
+    'transition-ui',
+    'focus:border-primary focus-visible:[outline-offset:0]',
+    'disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400',
+  ],
+  {
+    variants: {
+      size: {
+        lg: 'h-12',
+        md: 'h-10',
+      },
+      state: {
+        default: 'border-gray-300',
+        error: 'border-error focus:border-error',
+      },
+    },
+    defaultVariants: {
+      size: 'md',
+      state: 'default',
+    },
+  },
+);
+
+type InputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> &
+  VariantProps<typeof inputVariants> & {
+    label?: string;
+    hint?: string;
+    error?: string;
+    ref?: Ref<HTMLInputElement>;
+  };
+
+export function Input({
+  label,
+  hint,
+  error,
+  size,
+  required,
+  className,
+  id,
+  ref,
+  ...props
+}: InputProps) {
+  const inputId =
+    id ??
+    (label ? `input-${label.replace(/\s+/g, '-').toLowerCase()}` : undefined);
+  const errorId = error ? `${inputId}-error` : undefined;
+  const hintId = hint && !error ? `${inputId}-hint` : undefined;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {label && (
+        <label
+          htmlFor={inputId}
+          className="text-[0.875rem] font-semibold text-gray-900"
+        >
+          {label}
+          {required && (
+            <span aria-hidden="true" className="ml-0.5 text-error">
+              *
+            </span>
+          )}
+        </label>
+      )}
+      <input
+        ref={ref}
+        id={inputId}
+        required={required}
+        aria-required={required || undefined}
+        aria-describedby={
+          [errorId, hintId].filter(Boolean).join(' ') || undefined
+        }
+        aria-invalid={error ? true : undefined}
+        {...props}
+        className={cn(
+          inputVariants({ size, state: error ? 'error' : 'default' }),
+          className,
+        )}
+      />
+      {hint && !error && (
+        <p id={hintId} className="text-[0.8125rem] text-gray-500">
+          {hint}
+        </p>
+      )}
+      {error && (
+        <p
+          id={errorId}
+          role="alert"
+          aria-live="polite"
+          className="text-[0.8125rem] text-error"
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/shared/ui/Input/index.ts
+++ b/src/shared/ui/Input/index.ts
@@ -1,0 +1,1 @@
+export { Input } from './Input';

--- a/src/shared/ui/Radio/Radio.tsx
+++ b/src/shared/ui/Radio/Radio.tsx
@@ -1,0 +1,106 @@
+import type { InputHTMLAttributes, ReactNode, Ref } from 'react';
+import { cn } from '@/shared/utils/cn';
+
+/* ─── Radio ─────────────────────────────────────────────────────────── */
+
+type RadioProps = Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'type' | 'size'
+> & {
+  label?: string;
+  ref?: Ref<HTMLInputElement>;
+};
+
+export function Radio({ label, className, id, ref, ...props }: RadioProps) {
+  const inputId =
+    id ??
+    (label ? `radio-${label.replace(/\s+/g, '-').toLowerCase()}` : undefined);
+
+  return (
+    <label
+      htmlFor={inputId}
+      className="group inline-flex cursor-pointer items-center gap-2 has-[:disabled]:cursor-not-allowed"
+    >
+      {/* 시각적 라디오 */}
+      <span
+        aria-hidden="true"
+        className={cn(
+          'relative flex h-[1.125rem] w-[1.125rem] shrink-0 items-center justify-center rounded-full border transition-ui',
+          'border-gray-300 bg-white',
+          'group-has-[:checked]:border-primary',
+          'group-has-[:focus-visible]:outline group-has-[:focus-visible]:outline-2 group-has-[:focus-visible]:outline-primary group-has-[:focus-visible]:[outline-offset:2px]',
+          'group-has-[:disabled]:border-gray-300 group-has-[:disabled]:bg-gray-100',
+          className,
+        )}
+      >
+        {/* 내부 dot */}
+        <span className="hidden h-2 w-2 rounded-full bg-primary group-has-[:checked]:block group-has-[:disabled]:bg-gray-400" />
+      </span>
+
+      {/* 실제 input — sr-only로 접근성 유지, ref 전달 */}
+      <input
+        type="radio"
+        id={inputId}
+        ref={ref}
+        className="sr-only"
+        {...props}
+      />
+
+      {label && (
+        <span className="text-[0.875rem] font-normal text-gray-900 group-has-[:disabled]:text-gray-400">
+          {label}
+        </span>
+      )}
+    </label>
+  );
+}
+
+/* ─── RadioGroup ─────────────────────────────────────────────────────── */
+
+type RadioGroupProps = {
+  label?: string;
+  error?: string;
+  required?: boolean;
+  children: ReactNode;
+  className?: string;
+};
+
+export function RadioGroup({
+  label,
+  error,
+  required,
+  children,
+  className,
+}: RadioGroupProps) {
+  const errorId = error ? 'radiogroup-error' : undefined;
+
+  return (
+    <fieldset className={cn('flex flex-col gap-0 border-0 p-0', className)}>
+      {label && (
+        <legend className="mb-2 text-[0.875rem] font-semibold text-gray-900">
+          {label}
+          {required && (
+            <span aria-hidden="true" className="ml-0.5 text-error">
+              *
+            </span>
+          )}
+        </legend>
+      )}
+
+      <div className="flex flex-col gap-2" aria-describedby={errorId}>
+        {children}
+      </div>
+
+      {error && (
+        <p
+          id={errorId}
+          role="alert"
+          aria-live="polite"
+          className="mt-1.5 text-[0.8125rem] text-error"
+        >
+          {error}
+        </p>
+      )}
+    </fieldset>
+  );
+}

--- a/src/shared/ui/Radio/index.ts
+++ b/src/shared/ui/Radio/index.ts
@@ -1,0 +1,1 @@
+export { Radio, RadioGroup } from './Radio';

--- a/src/shared/utils/cn.ts
+++ b/src/shared/utils/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## 개요

shadcn/ui 방식(cva + cn + 비제어)을 기반으로 폼 컴포넌트를 새로 추가하고, 기존 Button도 동일 패턴으로 리팩터링했습니다. react-hook-form `register()` 스프레드만으로 연결됩니다.

## 주요 변경 사항

- `shared/utils/cn.ts` — clsx + tailwind-merge 합성 유틸 추가
- `shared/ui/Input` — label, required(\*), hint, error, size(lg/md) 지원
- `shared/ui/Checkbox` — label, error / `group-has-[:checked]` CSS 패턴으로 완전 커스텀 비주얼
- `shared/ui/Radio` + `RadioGroup` — fieldset/legend 시멘틱, error 지원
- `Button` — cva 기반 variant/size 분리, `buttonVariants` named export 추가
- `CLAUDE.md` — react-hook-form 허용, shadcn 컴포넌트 패턴 규칙 명시
- `docs/UI_guide.md` — Checkbox/Radio 스펙 추가, 폼 컴포넌트 패턴 섹션 추가

## react-hook-form 연결 예시

```tsx
<Input {...register('name')} error={errors.name?.message} label="이름" required />
<Checkbox {...register('agree')} error={errors.agree?.message} label="약관 동의" />
<RadioGroup label="성별" error={errors.gender?.message}>
  <Radio {...register('gender')} value="male" label="남성" />
  <Radio {...register('gender')} value="female" label="여성" />
</RadioGroup>
```

Closes #42