### PR TITLE
fix: survey Step1 생년월일 인풋 및 profile 표시 행 제거 #48

### DIFF
--- a/src/features/profile/ui/ProfileInfoTab.tsx
+++ b/src/features/profile/ui/ProfileInfoTab.tsx
@@ -71,7 +71,6 @@ export function ProfileInfoTab({
       <Section id="basic-info-heading" title="기본 정보">
         <dl>
           <InfoRow label="이름" value={childProfile.name} />
-          <InfoRow label="만 나이" value={`${childProfile.age}세`} />
           <InfoRow label="성별" value={childProfile.gender} />
           <InfoRow label="최종학력" value={childProfile.education} />
           <InfoRow label="희망 지역 1순위" value={region1Label} />

--- a/src/features/survey/ui/SurveyStep1.tsx
+++ b/src/features/survey/ui/SurveyStep1.tsx
@@ -63,19 +63,6 @@ export function SurveyStep1({
           maxLength={20}
         />
 
-        {/* 만 나이 */}
-        <Input
-          label="만 나이"
-          required
-          type="number"
-          min={1}
-          max={99}
-          value={values.age}
-          onChange={(e) => setField('age', e.target.value)}
-          error={errors.age}
-          placeholder="숫자만 입력해주세요"
-        />
-
         {/* 성별 */}
         <RadioGroup label="성별" required error={errors.gender}>
           <Radio


### PR DESCRIPTION
## 개요
생년월일 수집이 불필요하다고 판단되어 Survey Step1 인풋과 Profile 기본 정보 표시 행을 제거했습니다.

## 주요 변경 사항
- `SurveyStep1.tsx`: 생년월일 Input 필드 제거
- `ProfileInfoTab.tsx`: 기본 정보 섹션 생년월일 표시 행 제거

Closes #48