### PR TITLE
fix: checkbox always show check icon #50

### DIFF
--- a/src/shared/ui/Checkbox/Checkbox.tsx
+++ b/src/shared/ui/Checkbox/Checkbox.tsx
@@ -45,12 +45,7 @@ export function Checkbox({
           className,
         )}
       >
-        <Check
-          size={16}
-          strokeWidth={2}
-          aria-hidden="true"
-          className="hidden group-has-[:checked]:block"
-        />
+        <Check size={16} strokeWidth={2} aria-hidden="true" className="block" />
         <input
           type="checkbox"
           id={inputId}


### PR DESCRIPTION
## 개요
Checkbox 컴포넌트에서 미선택 상태에도 체크 아이콘이 항상 보이도록 수정했습니다.

## 주요 변경 사항
- `Checkbox.tsx`: Check 아이콘 className `hidden group-has-[:checked]:block` → `block`으로 변경

Closes #50