### PR TITLE
fix: remove unused imports and dead code from Profile components #52

### DIFF
--- a/src/features/profile/ui/ProfileEmptyView.tsx
+++ b/src/features/profile/ui/ProfileEmptyView.tsx
@@ -3,86 +3,23 @@
 import { useState } from 'react';
 import Link from 'next/link';
 
-import { ConfirmModal } from '@/shared/ui/ConfirmModal';
 import { ProfileSidebar } from './ProfileSidebar';
 
 type ProfileTab = 'result' | 'scraps';
 
-const MOBILE_TABS: { tab: ProfileTab; label: string }[] = [
-  { tab: 'result', label: '내 검사 결과' },
-  { tab: 'scraps', label: '스크랩한 공고' },
-];
-
 export function ProfileEmptyView() {
   const [activeTab, setActiveTab] = useState<ProfileTab>('result');
-  const [showWithdrawModal, setShowWithdrawModal] = useState(false);
-
-  const handleWithdraw = () => {
-    console.warn('[마주봄 목업] 회원 탈퇴 처리 → 화면 A로 이동 예정');
-    setShowWithdrawModal(false);
-  };
 
   return (
     <div className="mx-auto max-w-[1200px] px-4 py-10 md:px-5 lg:px-6">
       <div className="flex gap-8">
         {/* 데스크탑 사이드바 */}
         <div className="hidden w-[220px] shrink-0 md:block">
-          <ProfileSidebar
-            activeTab={activeTab}
-            onTabChange={setActiveTab}
-            onWithdrawClick={() => setShowWithdrawModal(true)}
-          />
+          <ProfileSidebar activeTab={activeTab} onTabChange={setActiveTab} />
         </div>
 
         {/* 콘텐츠 영역 */}
         <div className="min-w-0 flex-1">
-          {/* 모바일 탭 */}
-          <div className="mb-6 md:hidden">
-            <div
-              role="tablist"
-              aria-label="프로필 탭"
-              className="flex border-b border-gray-200"
-            >
-              {MOBILE_TABS.map(({ tab, label }) => (
-                <button
-                  key={tab}
-                  role="tab"
-                  type="button"
-                  aria-selected={activeTab === tab}
-                  onClick={() => setActiveTab(tab)}
-                  className={
-                    'transition-ui cursor-pointer px-4 py-3 text-[0.9375rem] font-semibold ' +
-                    (activeTab === tab
-                      ? 'border-b-2 border-primary text-primary'
-                      : 'border-b-2 border-transparent text-gray-500 hover:text-gray-900')
-                  }
-                >
-                  {label}
-                </button>
-              ))}
-            </div>
-
-            {/* 모바일 액션 버튼 */}
-            <div className="mt-3 flex items-center gap-4">
-              <Link
-                href="/survey"
-                className="transition-ui cursor-pointer text-[0.875rem] font-semibold text-primary hover:underline"
-              >
-                검사 시작하기
-              </Link>
-              <span className="text-gray-200" aria-hidden="true">
-                |
-              </span>
-              <button
-                type="button"
-                onClick={() => setShowWithdrawModal(true)}
-                className="transition-ui cursor-pointer text-[0.875rem] text-gray-400 hover:text-error"
-              >
-                회원 탈퇴
-              </button>
-            </div>
-          </div>
-
           {/* 빈 상태 */}
           <div className="flex flex-col items-center gap-6 rounded-lg border border-gray-200 bg-white py-20 text-center">
             <div className="flex flex-col gap-2">
@@ -102,18 +39,6 @@ export function ProfileEmptyView() {
           </div>
         </div>
       </div>
-
-      {showWithdrawModal && (
-        <ConfirmModal
-          title="회원 탈퇴"
-          description="탈퇴하면 모든 정보가 삭제됩니다. 정말 탈퇴하시겠습니까?"
-          confirmLabel="탈퇴하기"
-          cancelLabel="취소"
-          variant="destructive"
-          onConfirm={handleWithdraw}
-          onClose={() => setShowWithdrawModal(false)}
-        />
-      )}
     </div>
   );
 }

--- a/src/features/profile/ui/ProfileSidebar.tsx
+++ b/src/features/profile/ui/ProfileSidebar.tsx
@@ -1,11 +1,8 @@
-import Link from 'next/link';
-
 type ProfileTab = 'result' | 'scraps';
 
 type ProfileSidebarProps = {
   activeTab: ProfileTab;
   onTabChange: (tab: ProfileTab) => void;
-  onWithdrawClick: () => void;
 };
 
 const NAV_ITEMS: { tab: ProfileTab; label: string }[] = [
@@ -16,7 +13,6 @@ const NAV_ITEMS: { tab: ProfileTab; label: string }[] = [
 export function ProfileSidebar({
   activeTab,
   onTabChange,
-  onWithdrawClick,
 }: ProfileSidebarProps) {
   return (
     <nav

--- a/src/features/profile/ui/ProfileView.tsx
+++ b/src/features/profile/ui/ProfileView.tsx
@@ -1,9 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import Link from 'next/link';
 
-import { ConfirmModal } from '@/shared/ui/ConfirmModal';
 import { useProfile } from '../hooks/useProfile';
 import { useScrapedJobs } from '../hooks/useScrapedJobs';
 import { ProfileSidebar } from './ProfileSidebar';
@@ -12,14 +10,8 @@ import { ScrapedJobsTab } from './ScrapedJobsTab';
 
 type ProfileTab = 'result' | 'scraps';
 
-const MOBILE_TABS: { tab: ProfileTab; label: string }[] = [
-  { tab: 'result', label: '내 검사 결과' },
-  { tab: 'scraps', label: '스크랩한 공고' },
-];
-
 export function ProfileView() {
   const [activeTab, setActiveTab] = useState<ProfileTab>('result');
-  const [showWithdrawModal, setShowWithdrawModal] = useState(false);
 
   const {
     childProfile,
@@ -30,21 +22,12 @@ export function ProfileView() {
   } = useProfile();
   const { scrapedJobs, toggleBookmark } = useScrapedJobs();
 
-  const handleWithdraw = () => {
-    console.warn('[마주봄 목업] 회원 탈퇴 처리 → 화면 A로 이동 예정');
-    setShowWithdrawModal(false);
-  };
-
   return (
     <div className="mx-auto max-w-[1200px] px-4 py-10 md:px-5 lg:px-6">
       <div className="flex gap-8">
         {/* 데스크탑 사이드바 */}
         <div className="hidden w-[220px] shrink-0 md:block">
-          <ProfileSidebar
-            activeTab={activeTab}
-            onTabChange={setActiveTab}
-            onWithdrawClick={() => setShowWithdrawModal(true)}
-          />
+          <ProfileSidebar activeTab={activeTab} onTabChange={setActiveTab} />
         </div>
 
         {/* 콘텐츠 영역 */}


### PR DESCRIPTION
## 개요

ProfileView, ProfileEmptyView, ProfileSidebar에서 실제로 사용되지 않는 import, state, 함수, prop을 제거했다.

## 주요 변경 사항

- `ProfileView`: `Link`, `ConfirmModal` import 제거 / `MOBILE_TABS`, `showWithdrawModal`, `handleWithdraw` 제거 / `onWithdrawClick` prop 전달 제거
- `ProfileEmptyView`: 동일하게 미사용 코드 전체 제거
- `ProfileSidebar`: `Link` import 제거 / `onWithdrawClick` prop 제거

Closes #52