### PR TITLE
🚩feat: 카카오 로그인/로그아웃 구현 및 설문 POST API 추가 #57

### DIFF
--- a/src/app/api/oauth/kakao/callback/route.ts
+++ b/src/app/api/oauth/kakao/callback/route.ts
@@ -40,11 +40,16 @@ export async function GET(request: NextRequest) {
     const nickname = kakaoUser.kakao_account?.profile?.nickname ?? '사용자';
 
     // Step 3: Supabase users 테이블 upsert (kakao_id 기준)
-    const users = await supabaseFetch<{ id: number }[]>('/rest/v1/users', {
-      method: 'POST',
-      body: JSON.stringify({ kakao_id: kakaoId, nickname }),
-      headers: { Prefer: 'resolution=merge-duplicates,return=representation' },
-    });
+    const users = await supabaseFetch<{ id: number }[]>(
+      '/rest/v1/users?on_conflict=kakao_id',
+      {
+        method: 'POST',
+        body: JSON.stringify({ kakao_id: kakaoId, nickname }),
+        headers: {
+          Prefer: 'resolution=merge-duplicates,return=representation',
+        },
+      },
+    );
 
     const userId = String(users[0].id);
 

--- a/src/app/api/profiles/route.ts
+++ b/src/app/api/profiles/route.ts
@@ -1,0 +1,24 @@
+import { createAuthorizedRoute } from '@/shared/api/createAuthorizedRoute';
+import { supabaseFetch } from '@/shared/api/supabaseFetch';
+import { CreateProfileBodySchema, type Profile } from '@/shared/types/profile';
+
+export const POST = createAuthorizedRoute(async ({ userId, body }) => {
+  const parsed = CreateProfileBodySchema.safeParse(body);
+  if (!parsed.success) {
+    const err = new Error('입력값이 올바르지 않습니다.') as Error & {
+      status: number;
+    };
+    err.status = 400;
+    throw err;
+  }
+
+  const rows = await supabaseFetch<Profile[]>(
+    '/rest/v1/profiles?on_conflict=user_id',
+    {
+      method: 'POST',
+      body: JSON.stringify({ ...parsed.data, user_id: Number(userId) }),
+      headers: { Prefer: 'resolution=merge-duplicates,return=representation' },
+    },
+  );
+  return rows[0];
+});

--- a/src/features/survey/__tests__/surveyApi.test.ts
+++ b/src/features/survey/__tests__/surveyApi.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { submitSurvey } from '../api/surveyApi';
+
+vi.mock('@/shared/api/bffFetch', () => ({ bffFetch: vi.fn() }));
+
+import { bffFetch } from '@/shared/api/bffFetch';
+const mockBffFetch = vi.mocked(bffFetch);
+
+const body = {
+  name: '홍길동',
+  gender: '남성',
+  education: '고등학교 졸업',
+  region_primary: '서울특별시 강남구',
+  is_barrier_free: false,
+  disability_type: '지체',
+  disability_level: '3급',
+  mobility: '자유로움',
+  hand_usage: '양손 가능',
+  stamina: '보통',
+  communication: '원활',
+  instruction_level: '독립 수행',
+  hope_activities: ['사무'],
+};
+
+describe('surveyApi', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('POST /profiles를 올바른 body로 호출한다', async () => {
+    mockBffFetch.mockResolvedValue({ id: 1, user_id: 1, ...body });
+
+    await submitSurvey(body);
+
+    expect(mockBffFetch).toHaveBeenCalledWith('/profiles', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+  });
+
+  it('bffFetch 오류를 그대로 throw한다', async () => {
+    mockBffFetch.mockRejectedValue(new Error('네트워크 오류'));
+    await expect(submitSurvey(body)).rejects.toThrow('네트워크 오류');
+  });
+});

--- a/src/features/survey/__tests__/surveyRoute.test.ts
+++ b/src/features/survey/__tests__/surveyRoute.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '@/app/api/profiles/route';
+
+vi.mock('next/headers', () => ({ cookies: vi.fn() }));
+vi.mock('@/shared/api/supabaseFetch', () => ({ supabaseFetch: vi.fn() }));
+vi.mock('@/shared/utils/authCookies', () => ({ getAuthCookie: vi.fn() }));
+vi.mock('@/shared/utils/session', () => ({ verifySession: vi.fn() }));
+
+import { supabaseFetch } from '@/shared/api/supabaseFetch';
+import { getAuthCookie } from '@/shared/utils/authCookies';
+import { verifySession } from '@/shared/utils/session';
+
+const mockSupabaseFetch = vi.mocked(supabaseFetch);
+const mockGetAuthCookie = vi.mocked(getAuthCookie);
+const mockVerifySession = vi.mocked(verifySession);
+
+const mockAuth = (userId: string | null) => {
+  if (userId) {
+    mockGetAuthCookie.mockResolvedValue('token');
+    mockVerifySession.mockResolvedValue({ userId });
+  } else {
+    mockGetAuthCookie.mockResolvedValue(undefined);
+    mockVerifySession.mockResolvedValue(null);
+  }
+};
+
+const validBody = {
+  name: '홍길동',
+  gender: '남성',
+  education: '고등학교 졸업',
+  region_primary: '서울특별시 강남구',
+  is_barrier_free: false,
+  disability_type: '지체',
+  disability_level: '3급',
+  mobility: '자유로움',
+  hand_usage: '양손 가능',
+  stamina: '보통',
+  communication: '원활',
+  instruction_level: '독립 수행',
+  hope_activities: ['사무'],
+};
+
+const makeRequest = (body: unknown) =>
+  new Request('http://localhost/api/profiles', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+describe('POST /api/profiles', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('유효한 body로 프로필을 생성한다', async () => {
+    mockAuth('1');
+    mockSupabaseFetch.mockResolvedValue([{ id: 1, user_id: 1, ...validBody }]);
+
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+  });
+
+  it('쿠키 없으면 401을 반환한다', async () => {
+    mockAuth(null);
+
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(401);
+  });
+
+  it('필수 필드 누락 시 400을 반환한다', async () => {
+    mockAuth('1');
+
+    const res = await POST(makeRequest({ name: '' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('Supabase 오류 시 500을 반환한다', async () => {
+    mockAuth('1');
+    mockSupabaseFetch.mockRejectedValue(new Error('DB 오류'));
+
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/features/survey/api/surveyApi.ts
+++ b/src/features/survey/api/surveyApi.ts
@@ -1,0 +1,8 @@
+import { bffFetch } from '@/shared/api/bffFetch';
+import type { CreateProfileBody, Profile } from '@/shared/types/profile';
+
+export const submitSurvey = (body: CreateProfileBody): Promise<Profile> =>
+  bffFetch<Profile>('/profiles', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });

--- a/src/features/survey/hooks/useSurveyForm.ts
+++ b/src/features/survey/hooks/useSurveyForm.ts
@@ -2,11 +2,11 @@
 
 import { useState } from 'react';
 import { getSigunguList } from '../utils/regions';
+import { step1Schema, step2Schema } from '../utils/schema';
+import { submitSurvey } from '../api/surveyApi';
 
 export type SurveyFormValues = {
-  // Step 1
   name: string;
-  age: string;
   gender: string;
   education: string;
   region_primary_sido: string;
@@ -14,7 +14,6 @@ export type SurveyFormValues = {
   region_secondary_sido: string;
   region_secondary_sigungu: string;
   barrier_free: boolean;
-  // Step 2
   disability_type: string;
   disability_level: string;
   mobility: string;
@@ -26,9 +25,10 @@ export type SurveyFormValues = {
   hope_activities_other: string;
 };
 
+type FormErrors = Partial<Record<keyof SurveyFormValues, string>>;
+
 const INITIAL: SurveyFormValues = {
   name: '',
-  age: '',
   gender: '',
   education: '',
   region_primary_sido: '',
@@ -47,15 +47,29 @@ const INITIAL: SurveyFormValues = {
   hope_activities_other: '',
 };
 
+function parseZodErrors<T extends object>(
+  issues: { path: PropertyKey[]; message: string }[],
+): Partial<Record<keyof T, string>> {
+  const result: Partial<Record<keyof T, string>> = {};
+  for (const issue of issues) {
+    const key = issue.path[0] as keyof T;
+    if (key && !result[key]) result[key] = issue.message;
+  }
+  return result;
+}
+
 export function useSurveyForm() {
   const [step, setStep] = useState<1 | 2>(1);
   const [values, setValues] = useState<SurveyFormValues>(INITIAL);
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   function setField<K extends keyof SurveyFormValues>(
     key: K,
     value: SurveyFormValues[K],
   ) {
     setValues((prev) => ({ ...prev, [key]: value }));
+    setErrors((prev) => ({ ...prev, [key]: undefined }));
   }
 
   function onPrimarySidoChange(sido: string) {
@@ -83,9 +97,27 @@ export function useSurveyForm() {
         ? prev.hope_activities_other
         : '',
     }));
+    setErrors((prev) => ({ ...prev, hope_activities: undefined }));
   }
 
   function onNextStep() {
+    const result = step1Schema.safeParse({
+      name: values.name,
+      gender: values.gender,
+      education: values.education,
+      region_primary_sido: values.region_primary_sido,
+      region_primary_sigungu: values.region_primary_sigungu,
+      region_secondary_sido: values.region_secondary_sido,
+      region_secondary_sigungu: values.region_secondary_sigungu,
+      barrier_free: values.barrier_free,
+    });
+
+    if (!result.success) {
+      setErrors(parseZodErrors<SurveyFormValues>(result.error.issues));
+      return;
+    }
+
+    setErrors({});
     setStep(2);
   }
 
@@ -93,16 +125,66 @@ export function useSurveyForm() {
     setStep(1);
   }
 
-  function onSubmit() {
-    // eslint-disable-next-line no-console
-    console.log('제출완료');
+  async function onSubmit() {
+    const result = step2Schema.safeParse({
+      disability_type: values.disability_type,
+      disability_level: values.disability_level,
+      mobility: values.mobility,
+      hand_usage: values.hand_usage,
+      stamina: values.stamina,
+      communication: values.communication,
+      instruction_level: values.instruction_level,
+      hope_activities: values.hope_activities,
+      hope_activities_other: values.hope_activities_other,
+    });
+
+    if (!result.success) {
+      setErrors(parseZodErrors<SurveyFormValues>(result.error.issues));
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const activities = values.hope_activities.includes('기타')
+        ? [
+            ...values.hope_activities.filter((a) => a !== '기타'),
+            values.hope_activities_other.trim(),
+          ]
+        : values.hope_activities;
+
+      const regionSecondary =
+        values.region_secondary_sido && values.region_secondary_sigungu
+          ? `${values.region_secondary_sido} ${values.region_secondary_sigungu}`
+          : undefined;
+
+      await submitSurvey({
+        name: values.name,
+        gender: values.gender,
+        education: values.education,
+        region_primary: `${values.region_primary_sido} ${values.region_primary_sigungu}`,
+        region_secondary: regionSecondary,
+        is_barrier_free: values.barrier_free,
+        disability_type: values.disability_type,
+        disability_level: values.disability_level,
+        mobility: values.mobility,
+        hand_usage: values.hand_usage,
+        stamina: values.stamina,
+        communication: values.communication,
+        instruction_level: values.instruction_level,
+        hope_activities: activities,
+      });
+    } catch (err) {
+      console.error('[검사 제출 오류]', err);
+    } finally {
+      setIsSubmitting(false);
+    }
   }
 
   return {
     step,
     values,
-    errors: {} as Partial<Record<keyof SurveyFormValues, string>>,
-    isSubmitting: false,
+    errors,
+    isSubmitting,
     setField,
     onPrimarySidoChange,
     onSecondarySidoChange,

--- a/src/features/survey/utils/schema.ts
+++ b/src/features/survey/utils/schema.ts
@@ -2,13 +2,6 @@ import { z } from 'zod';
 
 export const step1Schema = z.object({
   name: z.string().min(1, '이름을 입력해주세요'),
-  age: z
-    .string()
-    .min(1, '만 나이를 입력해주세요')
-    .refine((v) => {
-      const n = Number(v);
-      return Number.isInteger(n) && n >= 1 && n <= 99;
-    }, '1~99 사이의 나이를 입력해주세요'),
   gender: z.string().min(1, '성별을 선택해주세요'),
   education: z.string().min(1, '최종학력을 선택해주세요'),
   region_primary_sido: z.string().min(1, '시·도를 선택해주세요'),

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,7 +3,7 @@ import { verifySession } from '@/shared/utils/session';
 
 const PROTECTED = ['/profile', '/survey'];
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   if (!PROTECTED.some((p) => pathname.startsWith(p))) {

--- a/src/shared/api/authApi.ts
+++ b/src/shared/api/authApi.ts
@@ -1,0 +1,4 @@
+import { bffFetch } from './bffFetch';
+
+export const logout = (): Promise<void> =>
+  bffFetch<void>('/auth/logout', { method: 'POST' });

--- a/src/shared/api/bffFetch.ts
+++ b/src/shared/api/bffFetch.ts
@@ -46,12 +46,7 @@ export const bffFetch = async <T>(
     try {
       await refreshTokenInternal();
       return await coreFetch<T>(url, requestOptions, timeoutMs);
-    } catch (refreshError) {
-      if (isApiError(refreshError) && refreshError.status === 401) {
-        if (typeof window !== 'undefined') {
-          window.location.href = '/';
-        }
-      }
+    } catch {
       throw err;
     }
   }

--- a/src/shared/hooks/useLogout.ts
+++ b/src/shared/hooks/useLogout.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { logout } from '@/shared/api/authApi';
+import { CURRENT_USER_QUERY_KEY } from './useCurrentUser';
+
+export function useLogout() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: logout,
+    onSuccess: () => {
+      queryClient.setQueryData(CURRENT_USER_QUERY_KEY, null);
+      window.location.href = '/';
+    },
+  });
+}

--- a/src/shared/types/profile.ts
+++ b/src/shared/types/profile.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+
+export const CreateProfileBodySchema = z.object({
+  name: z.string().min(1),
+  gender: z.string().min(1),
+  education: z.string().min(1),
+  region_primary: z.string().min(1),
+  region_secondary: z.string().optional(),
+  is_barrier_free: z.boolean(),
+  disability_type: z.string().min(1),
+  disability_level: z.string().min(1),
+  mobility: z.string().optional(),
+  hand_usage: z.string().min(1),
+  stamina: z.string().min(1),
+  communication: z.string().min(1),
+  instruction_level: z.string().min(1),
+  hope_activities: z.array(z.string()).min(1),
+});
+
+export type CreateProfileBody = z.infer<typeof CreateProfileBodySchema>;
+
+export type Profile = {
+  id: number;
+  user_id: number;
+  name: string;
+  gender: string;
+  education: string;
+  region_primary: string;
+  region_secondary: string | null;
+  is_barrier_free: boolean;
+  disability_type: string;
+  disability_level: string;
+  mobility: string | null;
+  hand_usage: string;
+  stamina: string;
+  communication: string;
+  instruction_level: string;
+  hope_activities: string[];
+  created_at: string;
+  updated_at: string;
+};

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -3,12 +3,13 @@
 import Link from 'next/link';
 import { User } from 'lucide-react';
 
-import { useMockState } from '@/shared/providers/mock-state-provider';
+import { useCurrentUser } from '@/shared/hooks/useCurrentUser';
+import { useLogout } from '@/shared/hooks/useLogout';
 import { Button } from '@/shared/ui/Button';
 
 export function Header() {
-  const { userState } = useMockState();
-  const isLoggedIn = userState === 'loggedIn' || userState === 'surveyed';
+  const { data: user } = useCurrentUser();
+  const { mutate: logout, isPending } = useLogout();
 
   return (
     <header className="border-b border-gray-200 bg-surface">
@@ -20,13 +21,19 @@ export function Header() {
           마주봄
         </Link>
 
-        {!isLoggedIn && (
-          <Button variant="secondary" size="md">
+        {!user && (
+          <Button
+            variant="secondary"
+            size="md"
+            onClick={() => {
+              window.location.href = '/api/oauth/kakao/authorize';
+            }}
+          >
             로그인
           </Button>
         )}
 
-        {isLoggedIn && (
+        {user && (
           <nav aria-label="사용자 메뉴" className="flex items-center gap-3">
             <Link
               href="/profile"
@@ -35,6 +42,14 @@ export function Header() {
             >
               <User size={20} strokeWidth={1.5} aria-hidden="true" />
             </Link>
+            <Button
+              variant="secondary"
+              size="md"
+              disabled={isPending}
+              onClick={() => logout()}
+            >
+              {isPending ? '로그아웃 중...' : '로그아웃'}
+            </Button>
           </nav>
         )}
       </div>


### PR DESCRIPTION
## 개요
카카오 OAuth 로그인/로그아웃을 실제 동작하도록 연결하고, 설문 결과를 Supabase에 저장하는 BFF POST API를 구현했습니다.

## 주요 변경 사항
- **Header**: 로그인 버튼 → `/api/oauth/kakao/authorize` 연결, 로그아웃 버튼 추가 (`useLogout`)
- **bffFetch**: 401 시 `window.location.href='/'` 제거 → 비인증 페이지에서 무한 리다이렉트 버그 수정
- **proxy.ts**: `middleware.ts` → `proxy.ts` 마이그레이션 (Next.js 16)
- **kakao callback**: `on_conflict=kakao_id` 누락으로 재로그인 시 409 오류 수정
- **POST /api/profiles**: Zod 검증 포함 프로필 upsert BFF 핸들러 신규 구현
- **useSurveyForm**: step1/step2 Zod 검증 연결, `submitSurvey` API 호출 추가
- **테스트**: surveyApi, surveyRoute 3종 세트(성공/401/400/500) 추가

Closes #57