### PR TITLE
🚩feat: 프로필 조회 API 추가 및 설문 편집 모드 구현 #59

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,14 +275,85 @@ if (!user) return <GuestView />;
 
 ---
 
-## 9. Component Rules
+## 9. DB 스키마 (확정)
+
+BFF에서 `supabaseFetch` (Secret key)로만 접근. RLS 불필요 — 서버에서 `user_id` 필터링.
+
+### 테이블
+
+```sql
+-- users
+create table users (
+  id         bigint generated always as identity primary key,
+  nickname   text        not null,
+  created_at timestamptz not null default now()
+);
+
+-- profiles
+create table profiles (
+  id                bigint generated always as identity primary key,
+  user_id           bigint      not null unique references users(id) on delete cascade,
+  name              text        not null,
+  gender            text        not null,
+  education         text        not null,
+  region_primary    text        not null,
+  region_secondary  text,
+  is_barrier_free   boolean     not null default false,
+  disability_type   text        not null,
+  disability_level  text        not null,
+  mobility          text        not null,
+  hand_usage        text        not null,
+  stamina           text        not null,
+  communication     text        not null,
+  instruction_level text        not null,
+  hope_activities   text[]      not null default '{}',
+  created_at        timestamptz not null default now(),
+  updated_at        timestamptz not null default now()
+);
+
+-- bookmarks
+create table bookmarks (
+  id            bigint generated always as identity primary key,
+  user_id       bigint      not null references users(id) on delete cascade,
+  posting_title text        not null,
+  posting_url   text        not null,
+  created_at    timestamptz not null default now(),
+  unique (user_id, posting_url)
+);
+
+-- match_results
+create table match_results (
+  id           bigint generated always as identity primary key,
+  user_id      bigint      not null unique references users(id) on delete cascade,
+  radar_chart  jsonb       not null default '{}',
+  summary_text text        not null default '',
+  top3_jobs    jsonb       not null default '[]',
+  created_at   timestamptz not null default now(),
+  updated_at   timestamptz not null default now()
+);
+```
+
+### 트리거
+
+- `profiles.updated_at`, `match_results.updated_at` → `set_updated_at()` 트리거로 자동 갱신
+
+### 관계
+
+- `profiles.user_id` → `users.id` (1:1, cascade)
+- `bookmarks.user_id` → `users.id` (1:N, cascade)
+- `match_results.user_id` → `users.id` (1:1, cascade)
+- `bookmarks` unique 제약: `(user_id, posting_url)`
+
+---
+
+## 10. Component Rules
 
 - Server Component 기본
 - 인터랙티브한 경우에만 `'use client'` 추가
 
 ---
 
-## 10. State Management
+## 11. State Management
 
 - 서버 상태: **TanStack Query** (유저 정보 포함 — Zustand 사용 금지)
 - UI/전역 상태: React Context
@@ -291,7 +362,7 @@ if (!user) return <GuestView />;
 
 ---
 
-## 11. UI 작업 규칙
+## 12. UI 작업 규칙
 
 **UI 컴포넌트(`shared/ui/`, `features/*/ui/`, `widgets/`)를 만들 때 반드시:**
 
@@ -353,7 +424,7 @@ const { register, handleSubmit, errors } = useSurveyForm();
 
 ---
 
-## 12. CRUD 규칙
+## 13. CRUD 규칙
 
 **CRUD 작업(`app/api/`, `features/*/api/`, `features/*/hooks/`)을 만들 때 반드시:**
 
@@ -407,7 +478,7 @@ pnpm test       # watch 모드
 
 ---
 
-## 13. PR 생성 절차
+## 14. PR 생성 절차
 
 **"PR 올려줘" 요청 시 반드시 `/ship` 커맨드를 실행한다.**
 

--- a/src/app/api/profiles/route.ts
+++ b/src/app/api/profiles/route.ts
@@ -2,6 +2,13 @@ import { createAuthorizedRoute } from '@/shared/api/createAuthorizedRoute';
 import { supabaseFetch } from '@/shared/api/supabaseFetch';
 import { CreateProfileBodySchema, type Profile } from '@/shared/types/profile';
 
+export const GET = createAuthorizedRoute(async ({ userId }) => {
+  const rows = await supabaseFetch<Profile[]>(
+    `/rest/v1/profiles?user_id=eq.${userId}&select=*`,
+  );
+  return rows[0] ?? null;
+});
+
 export const POST = createAuthorizedRoute(async ({ userId, body }) => {
   const parsed = CreateProfileBodySchema.safeParse(body);
   if (!parsed.success) {

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,26 +1,7 @@
 'use client';
 
-import { useEffect } from 'react';
-
-import { useMockState } from '@/shared/providers/mock-state-provider';
-import { DevStatePanel } from '@/shared/ui/DevStatePanel';
 import { ProfileView } from '@/features/profile';
-import { ProfileEmptyView } from '@/features/profile/ui/ProfileEmptyView';
 
 export default function ProfilePage() {
-  const { userState, setUserState } = useMockState();
-
-  // 프로필 페이지는 최소 로그인 상태
-  useEffect(() => {
-    if (userState === 'guest') {
-      setUserState('loggedIn');
-    }
-  }, [userState, setUserState]);
-
-  return (
-    <>
-      {userState === 'surveyed' ? <ProfileView /> : <ProfileEmptyView />}
-      <DevStatePanel />
-    </>
-  );
+  return <ProfileView />;
 }

--- a/src/app/survey/page.tsx
+++ b/src/app/survey/page.tsx
@@ -1,17 +1,23 @@
 'use client';
 
+import { Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { SurveyForm } from '@/features/survey/ui/SurveyForm';
 import { useSurveyForm } from '@/features/survey/hooks/useSurveyForm';
 
-export default function SurveyPage() {
-  const form = useSurveyForm();
+function SurveyContent() {
+  const searchParams = useSearchParams();
+  const mode = searchParams.get('mode') === 'edit' ? 'edit' : 'create';
+  const form = useSurveyForm(mode);
 
   return (
     <SurveyForm
+      mode={form.mode}
       step={form.step}
       values={form.values}
       errors={form.errors}
       isSubmitting={form.isSubmitting}
+      isComplete={form.isComplete}
       sigunguList={form.sigunguList}
       setField={form.setField}
       onPrimarySidoChange={form.onPrimarySidoChange}
@@ -20,6 +26,15 @@ export default function SurveyPage() {
       onNextStep={form.onNextStep}
       onPrevStep={form.onPrevStep}
       onSubmit={form.onSubmit}
+      onCompleteConfirm={form.onCompleteConfirm}
     />
+  );
+}
+
+export default function SurveyPage() {
+  return (
+    <Suspense>
+      <SurveyContent />
+    </Suspense>
   );
 }

--- a/src/features/profile/__tests__/profileApi.test.ts
+++ b/src/features/profile/__tests__/profileApi.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/shared/api/bffFetch', () => ({ bffFetch: vi.fn() }));
+
+import { bffFetch } from '@/shared/api/bffFetch';
+import { getProfile } from '../api/profileApi';
+
+const mockBffFetch = vi.mocked(bffFetch);
+
+describe('getProfile', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('GET /profiles를 호출한다', async () => {
+    const profile = { id: 1, user_id: 1, name: '홍길동' };
+    mockBffFetch.mockResolvedValue(profile);
+
+    const result = await getProfile();
+
+    expect(mockBffFetch).toHaveBeenCalledWith('/profiles', { method: 'GET' });
+    expect(result).toEqual(profile);
+  });
+
+  it('에러를 그대로 전파한다', async () => {
+    mockBffFetch.mockRejectedValue(new Error('네트워크 오류'));
+
+    await expect(getProfile()).rejects.toThrow('네트워크 오류');
+  });
+});

--- a/src/features/profile/__tests__/profileRoute.test.ts
+++ b/src/features/profile/__tests__/profileRoute.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from '@/app/api/profiles/route';
+
+vi.mock('next/headers', () => ({ cookies: vi.fn() }));
+vi.mock('@/shared/api/supabaseFetch', () => ({ supabaseFetch: vi.fn() }));
+vi.mock('@/shared/utils/authCookies', () => ({ getAuthCookie: vi.fn() }));
+vi.mock('@/shared/utils/session', () => ({ verifySession: vi.fn() }));
+
+import { supabaseFetch } from '@/shared/api/supabaseFetch';
+import { getAuthCookie } from '@/shared/utils/authCookies';
+import { verifySession } from '@/shared/utils/session';
+
+const mockSupabaseFetch = vi.mocked(supabaseFetch);
+const mockGetAuthCookie = vi.mocked(getAuthCookie);
+const mockVerifySession = vi.mocked(verifySession);
+
+const mockAuth = (userId: string | null) => {
+  if (userId) {
+    mockGetAuthCookie.mockResolvedValue('token');
+    mockVerifySession.mockResolvedValue({ userId });
+  } else {
+    mockGetAuthCookie.mockResolvedValue(undefined);
+    mockVerifySession.mockResolvedValue(null);
+  }
+};
+
+const makeRequest = () =>
+  new Request('http://localhost/api/profiles', { method: 'GET' });
+
+describe('GET /api/profiles', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('프로필을 조회한다', async () => {
+    mockAuth('1');
+    const profile = { id: 1, user_id: 1, name: '홍길동' };
+    mockSupabaseFetch.mockResolvedValue([profile]);
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.name).toBe('홍길동');
+  });
+
+  it('프로필이 없으면 null을 반환한다', async () => {
+    mockAuth('1');
+    mockSupabaseFetch.mockResolvedValue([]);
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data).toBeNull();
+  });
+
+  it('쿠키 없으면 401을 반환한다', async () => {
+    mockAuth(null);
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it('Supabase 오류 시 500을 반환한다', async () => {
+    mockAuth('1');
+    mockSupabaseFetch.mockRejectedValue(new Error('DB 오류'));
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/features/profile/api/profileApi.ts
+++ b/src/features/profile/api/profileApi.ts
@@ -1,0 +1,5 @@
+import { bffFetch } from '@/shared/api/bffFetch';
+import type { Profile } from '@/shared/types/profile';
+
+export const getProfile = (): Promise<Profile | null> =>
+  bffFetch<Profile | null>('/profiles', { method: 'GET' });

--- a/src/features/profile/hooks/useProfile.ts
+++ b/src/features/profile/hooks/useProfile.ts
@@ -1,15 +1,56 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { getProfile } from '../api/profileApi';
+import type { Profile } from '@/shared/types/profile';
+import type { ChildProfile } from '@/shared/types/childProfile';
 import {
-  MOCK_CHILD_PROFILE,
-  MOCK_USER_PROFILE,
   MOCK_PERSONALITY_AXES,
   MOCK_PERSONALITY_SUMMARY,
   MOCK_MATCHED_JOBS,
 } from '@/shared/utils/mockData';
 
-export function useProfile() {
+function parseRegion(region: string): { city: string; district: string } {
+  const parts = region.split(' ');
+  return { city: parts[0] ?? '', district: parts.slice(1).join(' ') };
+}
+
+function toChildProfile(p: Profile): ChildProfile {
   return {
-    childProfile: MOCK_CHILD_PROFILE,
-    lastSurveyDate: MOCK_USER_PROFILE.lastSurveyDate,
+    name: p.name,
+    age: 0,
+    gender: p.gender as ChildProfile['gender'],
+    education: p.education,
+    region1: parseRegion(p.region_primary),
+    region2: p.region_secondary ? parseRegion(p.region_secondary) : undefined,
+    barrierFree: p.is_barrier_free,
+    disabilityType: p.disability_type as ChildProfile['disabilityType'],
+    disabilityGrade: p.disability_level as ChildProfile['disabilityGrade'],
+    mobility: p.mobility as ChildProfile['mobility'],
+    handUse: p.hand_usage as ChildProfile['handUse'],
+    stamina: p.stamina as ChildProfile['stamina'],
+    speaking: p.communication as ChildProfile['speaking'],
+    instructionUnderstanding:
+      p.instruction_level as ChildProfile['instructionUnderstanding'],
+    preferredActivities: p.hope_activities,
+  };
+}
+
+export function useProfile() {
+  const { data: profile, isLoading } = useQuery({
+    queryKey: ['profile'],
+    queryFn: getProfile,
+  });
+
+  const childProfile = profile ? toChildProfile(profile) : null;
+
+  return {
+    profile,
+    childProfile,
+    isLoading,
+    lastSurveyDate: profile
+      ? new Date(profile.updated_at).toLocaleDateString('ko-KR')
+      : '',
     personalityAxes: MOCK_PERSONALITY_AXES,
     personalitySummary: MOCK_PERSONALITY_SUMMARY,
     matchedJobs: MOCK_MATCHED_JOBS,

--- a/src/features/profile/ui/ProfileInfoTab.tsx
+++ b/src/features/profile/ui/ProfileInfoTab.tsx
@@ -10,6 +10,7 @@ type ProfileInfoTabProps = {
   personalityAxes: PersonalityAxis[];
   personalitySummary: string;
   matchedJobs: MatchedJob[];
+  onEdit: () => void;
 };
 
 type InfoRowProps = { label: string; value: string };
@@ -50,6 +51,7 @@ export function ProfileInfoTab({
   personalityAxes,
   personalitySummary,
   matchedJobs,
+  onEdit,
 }: ProfileInfoTabProps) {
   const region1Label = `${childProfile.region1.city} ${childProfile.region1.district}`;
   const region2Label = childProfile.region2
@@ -68,7 +70,7 @@ export function ProfileInfoTab({
             마지막 검사일: {lastSurveyDate}
           </p>
         </div>
-        <Button variant="secondary" size="sm" type="button">
+        <Button variant="secondary" size="sm" type="button" onClick={onEdit}>
           <Pencil size={16} strokeWidth={1.5} aria-hidden="true" />
           프로필 수정
         </Button>

--- a/src/features/profile/ui/ProfileView.tsx
+++ b/src/features/profile/ui/ProfileView.tsx
@@ -1,20 +1,25 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 import { useProfile } from '../hooks/useProfile';
 import { useScrapedJobs } from '../hooks/useScrapedJobs';
 import { ProfileSidebar } from './ProfileSidebar';
 import { ProfileInfoTab } from './ProfileInfoTab';
+import { ProfileEmptyView } from './ProfileEmptyView';
 import { ScrapedJobsTab } from './ScrapedJobsTab';
+import { Skeleton } from '@/shared/ui/Skeleton';
 
 type ProfileTab = 'result' | 'scraps';
 
 export function ProfileView() {
+  const router = useRouter();
   const [activeTab, setActiveTab] = useState<ProfileTab>('result');
 
   const {
     childProfile,
+    isLoading,
     lastSurveyDate,
     personalityAxes,
     personalitySummary,
@@ -22,17 +27,38 @@ export function ProfileView() {
   } = useProfile();
   const { scrapedJobs, toggleBookmark } = useScrapedJobs();
 
+  if (isLoading) {
+    return (
+      <div className="mx-auto max-w-[1200px] px-4 py-10 md:px-5 lg:px-6">
+        <div className="flex gap-8">
+          <div className="hidden w-[220px] shrink-0 md:block">
+            <Skeleton className="h-[100px] rounded-lg" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <Skeleton className="mb-4 h-8 w-[200px]" />
+            <Skeleton className="h-[300px] rounded-lg" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!childProfile) {
+    return <ProfileEmptyView />;
+  }
+
+  function handleEdit() {
+    router.push('/survey?mode=edit');
+  }
+
   return (
     <div className="mx-auto max-w-[1200px] px-4 py-10 md:px-5 lg:px-6">
       <div className="flex gap-8">
-        {/* 데스크탑 사이드바 */}
         <div className="hidden w-[220px] shrink-0 md:block">
           <ProfileSidebar activeTab={activeTab} onTabChange={setActiveTab} />
         </div>
 
-        {/* 콘텐츠 영역 */}
         <div className="min-w-0 flex-1">
-          {/* 탭 콘텐츠 */}
           {activeTab === 'result' ? (
             <ProfileInfoTab
               childProfile={childProfile}
@@ -40,6 +66,7 @@ export function ProfileView() {
               personalityAxes={personalityAxes}
               personalitySummary={personalitySummary}
               matchedJobs={matchedJobs}
+              onEdit={handleEdit}
             />
           ) : (
             <ScrapedJobsTab

--- a/src/features/survey/hooks/useSurveyForm.ts
+++ b/src/features/survey/hooks/useSurveyForm.ts
@@ -1,9 +1,13 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getSigunguList } from '../utils/regions';
 import { step1Schema, step2Schema } from '../utils/schema';
 import { submitSurvey } from '../api/surveyApi';
+import { getProfile } from '@/features/profile/api/profileApi';
+import type { Profile } from '@/shared/types/profile';
 
 export type SurveyFormValues = {
   name: string;
@@ -47,6 +51,39 @@ const INITIAL: SurveyFormValues = {
   hope_activities_other: '',
 };
 
+function profileToFormValues(p: Profile): SurveyFormValues {
+  const [primarySido = '', ...primaryRest] = p.region_primary.split(' ');
+  const primarySigungu = primaryRest.join(' ');
+
+  let secondarySido = '';
+  let secondarySigungu = '';
+  if (p.region_secondary) {
+    const [sido = '', ...rest] = p.region_secondary.split(' ');
+    secondarySido = sido;
+    secondarySigungu = rest.join(' ');
+  }
+
+  return {
+    name: p.name,
+    gender: p.gender,
+    education: p.education,
+    region_primary_sido: primarySido,
+    region_primary_sigungu: primarySigungu,
+    region_secondary_sido: secondarySido,
+    region_secondary_sigungu: secondarySigungu,
+    barrier_free: p.is_barrier_free,
+    disability_type: p.disability_type,
+    disability_level: p.disability_level,
+    mobility: p.mobility ?? '',
+    hand_usage: p.hand_usage,
+    stamina: p.stamina,
+    communication: p.communication,
+    instruction_level: p.instruction_level,
+    hope_activities: p.hope_activities,
+    hope_activities_other: '',
+  };
+}
+
 function parseZodErrors<T extends object>(
   issues: { path: PropertyKey[]; message: string }[],
 ): Partial<Record<keyof T, string>> {
@@ -58,11 +95,28 @@ function parseZodErrors<T extends object>(
   return result;
 }
 
-export function useSurveyForm() {
+export function useSurveyForm(mode: 'create' | 'edit' = 'create') {
+  const router = useRouter();
+  const queryClient = useQueryClient();
   const [step, setStep] = useState<1 | 2>(1);
   const [values, setValues] = useState<SurveyFormValues>(INITIAL);
   const [errors, setErrors] = useState<FormErrors>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isComplete, setIsComplete] = useState(false);
+  const [initialized, setInitialized] = useState(mode === 'create');
+
+  const { data: existingProfile } = useQuery({
+    queryKey: ['profile'],
+    queryFn: getProfile,
+    enabled: mode === 'edit',
+  });
+
+  useEffect(() => {
+    if (mode === 'edit' && existingProfile && !initialized) {
+      setValues(profileToFormValues(existingProfile));
+      setInitialized(true);
+    }
+  }, [mode, existingProfile, initialized]);
 
   function setField<K extends keyof SurveyFormValues>(
     key: K,
@@ -173,6 +227,9 @@ export function useSurveyForm() {
         instruction_level: values.instruction_level,
         hope_activities: activities,
       });
+
+      queryClient.invalidateQueries({ queryKey: ['profile'] });
+      setIsComplete(true);
     } catch (err) {
       console.error('[검사 제출 오류]', err);
     } finally {
@@ -180,11 +237,17 @@ export function useSurveyForm() {
     }
   }
 
+  function onCompleteConfirm() {
+    router.push('/profile');
+  }
+
   return {
+    mode,
     step,
     values,
     errors,
     isSubmitting,
+    isComplete,
     setField,
     onPrimarySidoChange,
     onSecondarySidoChange,
@@ -192,6 +255,7 @@ export function useSurveyForm() {
     onNextStep,
     onPrevStep,
     onSubmit,
+    onCompleteConfirm,
     sigunguList: {
       primary: getSigunguList(values.region_primary_sido),
       secondary: getSigunguList(values.region_secondary_sido),

--- a/src/features/survey/ui/SurveyForm.tsx
+++ b/src/features/survey/ui/SurveyForm.tsx
@@ -1,12 +1,15 @@
 import type { SurveyFormValues } from '../hooks/useSurveyForm';
+import { ConfirmModal } from '@/shared/ui/ConfirmModal';
 import { SurveyStep1 } from './SurveyStep1';
 import { SurveyStep2 } from './SurveyStep2';
 
 type Props = {
+  mode: 'create' | 'edit';
   step: 1 | 2;
   values: SurveyFormValues;
   errors: Partial<Record<keyof SurveyFormValues, string>>;
   isSubmitting: boolean;
+  isComplete: boolean;
   sigunguList: { primary: string[]; secondary: string[] };
   setField: <K extends keyof SurveyFormValues>(
     key: K,
@@ -18,13 +21,16 @@ type Props = {
   onNextStep: () => void;
   onPrevStep: () => void;
   onSubmit: () => void;
+  onCompleteConfirm: () => void;
 };
 
 export function SurveyForm({
+  mode,
   step,
   values,
   errors,
   isSubmitting,
+  isComplete,
   sigunguList,
   setField,
   onPrimarySidoChange,
@@ -33,12 +39,15 @@ export function SurveyForm({
   onNextStep,
   onPrevStep,
   onSubmit,
+  onCompleteConfirm,
 }: Props) {
+  const isEdit = mode === 'edit';
+
   return (
     <div className="mx-auto max-w-[640px] px-4 py-10 md:px-5 md:py-14 lg:px-6">
       {/* 페이지 타이틀 */}
       <h1 className="mb-2 text-[1.75rem] font-bold leading-[1.35] text-gray-900">
-        자녀 특성 검사
+        {isEdit ? '검사 내용 수정' : '자녀 특성 검사'}
       </h1>
       <p className="mb-8 text-[0.9375rem] text-gray-500">
         자녀의 특성을 입력하면 AI가 적합한 직종과 채용공고를 찾아드려요
@@ -81,6 +90,7 @@ export function SurveyForm({
         />
       ) : (
         <SurveyStep2
+          mode={mode}
           values={values}
           errors={errors}
           setField={setField}
@@ -88,6 +98,21 @@ export function SurveyForm({
           onPrevStep={onPrevStep}
           onSubmit={onSubmit}
           isSubmitting={isSubmitting}
+        />
+      )}
+
+      {isComplete && (
+        <ConfirmModal
+          title={isEdit ? '수정 완료' : '검사 완료'}
+          description={
+            isEdit
+              ? '검사 내용이 수정되었습니다! 결과를 확인해보세요.'
+              : '검사가 완료되었습니다! 결과를 확인해보세요.'
+          }
+          confirmLabel="결과 보기"
+          cancelLabel="닫기"
+          onConfirm={onCompleteConfirm}
+          onClose={onCompleteConfirm}
         />
       )}
     </div>

--- a/src/features/survey/ui/SurveyStep2.tsx
+++ b/src/features/survey/ui/SurveyStep2.tsx
@@ -61,6 +61,7 @@ const HOPE_ACTIVITIES_OPTIONS = [
 ];
 
 type Props = {
+  mode: 'create' | 'edit';
   values: SurveyFormValues;
   errors: Partial<Record<keyof SurveyFormValues, string>>;
   setField: <K extends keyof SurveyFormValues>(
@@ -74,6 +75,7 @@ type Props = {
 };
 
 export function SurveyStep2({
+  mode,
   values,
   errors,
   setField,
@@ -82,6 +84,7 @@ export function SurveyStep2({
   onSubmit,
   isSubmitting,
 }: Props) {
+  const submitLabel = mode === 'edit' ? '수정 완료' : '검사 완료';
   function handleActivityChange(value: string, checked: boolean) {
     const next = checked
       ? [...values.hope_activities, value]
@@ -262,7 +265,7 @@ export function SurveyStep2({
           disabled={isSubmitting}
           aria-disabled={isSubmitting}
         >
-          {isSubmitting ? '처리 중...' : '검사 완료'}
+          {isSubmitting ? '처리 중...' : submitLabel}
         </Button>
       </div>
     </section>


### PR DESCRIPTION
## 개요
프로필 조회 GET API를 추가하고, 프로필 페이지를 실제 데이터로 연결하며, 설문 편집 모드를 구현했습니다.

## 주요 변경 사항
- **GET /api/profiles** — 로그인 유저의 프로필 조회 API 추가
- **프로필 페이지 실데이터 연결** — mock state 제거, `useProfile` 훅이 실제 API 호출 (AI 성향분석은 목데이터 유지)
- **설문 편집 모드** — `/survey?mode=edit` 시 기존 데이터 pre-fill, 타이틀/버튼/모달 텍스트 분기
- **검사 완료 모달** — 제출 성공 시 "검사 완료"/"수정 완료" 모달 → "결과 보기" 클릭 → `/profile` 이동
- **프로필 수정 버튼** — `/survey?mode=edit`로 네비게이션 연결
- **Feature API 레이어** — `profileApi.ts` + 테스트 (route 4건, api 2건)
- **DB 스키마** — CLAUDE.md 섹션 9에 확정 스키마 추가

## 변경 파일
- `CLAUDE.md` — DB 스키마 섹션 추가
- `src/app/api/profiles/route.ts` — GET 핸들러 추가
- `src/app/profile/page.tsx` — mock state 제거, ProfileView에 위임
- `src/app/survey/page.tsx` — mode 파라미터 읽기 + Suspense 래핑
- `src/features/profile/` — api, hooks, ui, tests 추가/수정
- `src/features/survey/` — hooks, ui 편집 모드 대응

Closes #59