### PR TITLE
feat: userProfile 타입 리네이밍 및 survey 폼 이탈 방지

### DIFF
--- a/src/app/dev/components/page.tsx
+++ b/src/app/dev/components/page.tsx
@@ -335,7 +335,7 @@ export default function ComponentsDevPage() {
         <Row label="기본">
           <div className="w-full">
             <AIResultCard
-              childName="김지수"
+              userName="김지수"
               axes={SAMPLE_AXES}
               summary="반복적이고 정확한 업무 처리에 강점이 있으며, 혼자 집중할 수 있는 환경에서 높은 성과를 냅니다."
               jobs={SAMPLE_MATCHED_JOBS}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import { QueryProvider } from '@/shared/providers/query-provider';
 import { MockStateProvider } from '@/shared/providers/mock-state-provider';
+import { NavigationTracker } from '@/shared/providers/NavigationTracker';
 import { Header } from '@/widgets/header';
 import { Footer } from '@/widgets/footer';
 import './globals.css';
@@ -31,6 +32,7 @@ export default function RootLayout({
         </a>
         <QueryProvider>
           <MockStateProvider>
+            <NavigationTracker />
             <Header />
             <main id="main-content" className="flex-1">
               {children}

--- a/src/app/survey/page.tsx
+++ b/src/app/survey/page.tsx
@@ -4,11 +4,13 @@ import { Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { SurveyForm } from '@/features/survey/ui/SurveyForm';
 import { useSurveyForm } from '@/features/survey/hooks/useSurveyForm';
+import { usePreventNavigation } from '@/features/survey/hooks/usePreventNavigation';
 
 function SurveyContent() {
   const searchParams = useSearchParams();
   const mode = searchParams.get('mode') === 'edit' ? 'edit' : 'create';
   const form = useSurveyForm(mode);
+  const { isBlocking, onStay, onLeave } = usePreventNavigation(form.isDirty);
 
   return (
     <SurveyForm
@@ -18,6 +20,7 @@ function SurveyContent() {
       errors={form.errors}
       isSubmitting={form.isSubmitting}
       isComplete={form.isComplete}
+      isBlocking={isBlocking}
       sigunguList={form.sigunguList}
       setField={form.setField}
       onPrimarySidoChange={form.onPrimarySidoChange}
@@ -28,6 +31,8 @@ function SurveyContent() {
       onPrevStep={form.onPrevStep}
       onSubmit={form.onSubmit}
       onCompleteConfirm={form.onCompleteConfirm}
+      onStay={onStay}
+      onLeave={onLeave}
     />
   );
 }

--- a/src/features/dashboard/hooks/useDashboard.ts
+++ b/src/features/dashboard/hooks/useDashboard.ts
@@ -7,8 +7,7 @@ import {
 
 export function useDashboard() {
   return {
-    childName: MOCK_USER_PROFILE.name,
-    lastSurveyDate: MOCK_USER_PROFILE.lastSurveyDate,
+    userName: MOCK_USER_PROFILE.name,
     personalityAxes: MOCK_PERSONALITY_AXES,
     personalitySummary: MOCK_PERSONALITY_SUMMARY,
     matchedJobs: MOCK_MATCHED_JOBS,

--- a/src/features/dashboard/ui/DashboardView.tsx
+++ b/src/features/dashboard/ui/DashboardView.tsx
@@ -6,7 +6,7 @@ import { JobListSection } from './JobListSection';
 import { AIResultCard } from '@/shared/ui/AIResultCard';
 
 export function DashboardView() {
-  const { childName, personalityAxes, personalitySummary, matchedJobs } =
+  const { userName, personalityAxes, personalitySummary, matchedJobs } =
     useDashboard();
   const { postings, toggleBookmark } = useJobPostings();
 
@@ -18,7 +18,7 @@ export function DashboardView() {
             검사 결과 요약
           </h2>
           <AIResultCard
-            childName={childName}
+            userName={userName}
             axes={personalityAxes}
             summary={personalitySummary}
             jobs={matchedJobs}
@@ -30,7 +30,7 @@ export function DashboardView() {
             맞춤 채용공고
           </h2>
           <JobListSection
-            childName={childName}
+            userName={userName}
             postings={postings}
             onBookmarkToggle={toggleBookmark}
           />

--- a/src/features/dashboard/ui/JobListSection.tsx
+++ b/src/features/dashboard/ui/JobListSection.tsx
@@ -5,14 +5,14 @@ import { Skeleton } from '@/shared/ui/Skeleton';
 import { JobCard } from './JobCard';
 
 type JobListSectionProps = {
-  childName: string;
+  userName: string;
   postings: JobPosting[];
   onBookmarkToggle: (id: number) => void;
   isLoading?: boolean;
 };
 
 export function JobListSection({
-  childName,
+  userName,
   postings,
   onBookmarkToggle,
   isLoading = false,
@@ -23,7 +23,7 @@ export function JobListSection({
         id="job-list-heading"
         className="mb-5 border-l-[3px] border-primary pl-[10px] text-[1rem] font-semibold leading-[1.5] text-gray-900"
       >
-        {childName}님에게 맞는 채용공고
+        {userName}님에게 맞는 채용공고
       </h2>
 
       {isLoading ? (

--- a/src/features/profile/hooks/useProfile.ts
+++ b/src/features/profile/hooks/useProfile.ts
@@ -3,7 +3,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { getProfile } from '../api/profileApi';
 import type { Profile } from '@/shared/types/profile';
-import type { ChildProfile } from '@/shared/types/childProfile';
+import type { UserProfile } from '@/shared/types/userProfile';
 import {
   MOCK_PERSONALITY_AXES,
   MOCK_PERSONALITY_SUMMARY,
@@ -15,23 +15,23 @@ function parseRegion(region: string): { city: string; district: string } {
   return { city: parts[0] ?? '', district: parts.slice(1).join(' ') };
 }
 
-function toChildProfile(p: Profile): ChildProfile {
+function toUserProfile(p: Profile): UserProfile {
   return {
     name: p.name,
     age: 0,
-    gender: p.gender as ChildProfile['gender'],
+    gender: p.gender as UserProfile['gender'],
     education: p.education,
     region1: parseRegion(p.region_primary),
     region2: p.region_secondary ? parseRegion(p.region_secondary) : undefined,
     barrierFree: p.is_barrier_free,
-    disabilityType: p.disability_type as ChildProfile['disabilityType'],
-    disabilityGrade: p.disability_level as ChildProfile['disabilityGrade'],
-    mobility: p.mobility as ChildProfile['mobility'],
-    handUse: p.hand_usage as ChildProfile['handUse'],
-    stamina: p.stamina as ChildProfile['stamina'],
-    speaking: p.communication as ChildProfile['speaking'],
+    disabilityType: p.disability_type as UserProfile['disabilityType'],
+    disabilityGrade: p.disability_level as UserProfile['disabilityGrade'],
+    mobility: p.mobility as UserProfile['mobility'],
+    handUse: p.hand_usage as UserProfile['handUse'],
+    stamina: p.stamina as UserProfile['stamina'],
+    speaking: p.communication as UserProfile['speaking'],
     instructionUnderstanding:
-      p.instruction_level as ChildProfile['instructionUnderstanding'],
+      p.instruction_level as UserProfile['instructionUnderstanding'],
     preferredActivities: p.hope_activities,
   };
 }
@@ -42,11 +42,11 @@ export function useProfile() {
     queryFn: getProfile,
   });
 
-  const childProfile = profile ? toChildProfile(profile) : null;
+  const userProfile = profile ? toUserProfile(profile) : null;
 
   return {
     profile,
-    childProfile,
+    userProfile,
     isLoading,
     lastSurveyDate: profile
       ? new Date(profile.updated_at).toLocaleDateString('ko-KR')

--- a/src/features/profile/ui/ProfileInfoTab.tsx
+++ b/src/features/profile/ui/ProfileInfoTab.tsx
@@ -1,11 +1,11 @@
 import { Pencil } from 'lucide-react';
-import type { ChildProfile } from '@/shared/types/childProfile';
+import type { UserProfile } from '@/shared/types/userProfile';
 import type { MatchedJob, PersonalityAxis } from '@/shared/types/job';
 import { AIResultCard } from '@/shared/ui/AIResultCard';
 import { Button } from '@/shared/ui/Button';
 
 type ProfileInfoTabProps = {
-  childProfile: ChildProfile;
+  userProfile: UserProfile;
   lastSurveyDate: string;
   personalityAxes: PersonalityAxis[];
   personalitySummary: string;
@@ -46,16 +46,16 @@ function Section({ id, title, children }: SectionProps) {
 }
 
 export function ProfileInfoTab({
-  childProfile,
+  userProfile,
   lastSurveyDate,
   personalityAxes,
   personalitySummary,
   matchedJobs,
   onEdit,
 }: ProfileInfoTabProps) {
-  const region1Label = `${childProfile.region1.city} ${childProfile.region1.district}`;
-  const region2Label = childProfile.region2
-    ? `${childProfile.region2.city} ${childProfile.region2.district}`
+  const region1Label = `${userProfile.region1.city} ${userProfile.region1.district}`;
+  const region2Label = userProfile.region2
+    ? `${userProfile.region2.city} ${userProfile.region2.district}`
     : '없음';
 
   return (
@@ -64,7 +64,7 @@ export function ProfileInfoTab({
       <header className="flex items-start justify-between gap-4">
         <div>
           <h1 className="text-[1.125rem] font-bold leading-[1.35] text-gray-900">
-            {childProfile.name}님의 프로필
+            {userProfile.name}님의 프로필
           </h1>
           <p className="mt-1 text-[0.875rem] text-gray-500">
             마지막 검사일: {lastSurveyDate}
@@ -79,7 +79,7 @@ export function ProfileInfoTab({
       {/* AI 성향 분석 결과 */}
       <section aria-labelledby="ai-result-heading">
         <AIResultCard
-          childName={childProfile.name}
+          userName={userProfile.name}
           axes={personalityAxes}
           summary={personalitySummary}
           jobs={matchedJobs}
@@ -89,14 +89,14 @@ export function ProfileInfoTab({
       {/* 기본 정보 */}
       <Section id="basic-info-heading" title="기본 정보">
         <dl>
-          <InfoRow label="이름" value={childProfile.name} />
-          <InfoRow label="성별" value={childProfile.gender} />
-          <InfoRow label="최종학력" value={childProfile.education} />
+          <InfoRow label="이름" value={userProfile.name} />
+          <InfoRow label="성별" value={userProfile.gender} />
+          <InfoRow label="최종학력" value={userProfile.education} />
           <InfoRow label="희망 지역 1순위" value={region1Label} />
           <InfoRow label="희망 지역 2순위" value={region2Label} />
           <InfoRow
             label="이동 경로 베리어 프리"
-            value={childProfile.barrierFree ? '해당' : '해당 없음'}
+            value={userProfile.barrierFree ? '해당' : '해당 없음'}
           />
         </dl>
       </Section>
@@ -104,15 +104,15 @@ export function ProfileInfoTab({
       {/* 신체 조건 */}
       <Section id="physical-info-heading" title="신체 조건">
         <dl>
-          <InfoRow label="장애 유형" value={childProfile.disabilityType} />
-          <InfoRow label="장애 등급" value={childProfile.disabilityGrade} />
-          <InfoRow label="이동" value={childProfile.mobility} />
-          <InfoRow label="손 사용" value={childProfile.handUse} />
-          <InfoRow label="체력" value={childProfile.stamina} />
-          <InfoRow label="말하기" value={childProfile.speaking} />
+          <InfoRow label="장애 유형" value={userProfile.disabilityType} />
+          <InfoRow label="장애 등급" value={userProfile.disabilityGrade} />
+          <InfoRow label="이동" value={userProfile.mobility} />
+          <InfoRow label="손 사용" value={userProfile.handUse} />
+          <InfoRow label="체력" value={userProfile.stamina} />
+          <InfoRow label="말하기" value={userProfile.speaking} />
           <InfoRow
             label="지시 이해"
-            value={childProfile.instructionUnderstanding}
+            value={userProfile.instructionUnderstanding}
           />
         </dl>
       </Section>
@@ -120,7 +120,7 @@ export function ProfileInfoTab({
       {/* 희망 활동 유형 */}
       <Section id="activity-heading" title="희망 활동 유형">
         <ul className="flex flex-wrap gap-2" aria-label="선택된 희망 활동 유형">
-          {childProfile.preferredActivities.map((activity) => (
+          {userProfile.preferredActivities.map((activity) => (
             <li
               key={activity}
               className="inline-flex h-6 items-center rounded-sm bg-primary-tag px-2 text-[0.75rem] font-semibold text-primary-pressed"

--- a/src/features/profile/ui/ProfileView.tsx
+++ b/src/features/profile/ui/ProfileView.tsx
@@ -18,7 +18,7 @@ export function ProfileView() {
   const [activeTab, setActiveTab] = useState<ProfileTab>('result');
 
   const {
-    childProfile,
+    userProfile,
     isLoading,
     lastSurveyDate,
     personalityAxes,
@@ -43,7 +43,7 @@ export function ProfileView() {
     );
   }
 
-  if (!childProfile) {
+  if (!userProfile) {
     return <ProfileEmptyView />;
   }
 
@@ -61,7 +61,7 @@ export function ProfileView() {
         <div className="min-w-0 flex-1">
           {activeTab === 'result' ? (
             <ProfileInfoTab
-              childProfile={childProfile}
+              userProfile={userProfile}
               lastSurveyDate={lastSurveyDate}
               personalityAxes={personalityAxes}
               personalitySummary={personalitySummary}

--- a/src/features/survey/hooks/usePreventNavigation.ts
+++ b/src/features/survey/hooks/usePreventNavigation.ts
@@ -1,0 +1,87 @@
+'use client';
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { useRouter, usePathname } from 'next/navigation';
+import { getPreviousUrl } from '@/shared/utils/urlHistory';
+
+/**
+ * 폼에 변경사항이 있을 때 의도치 않은 페이지 이탈을 막는 훅.
+ * - 새로고침 / 탭 닫기 (beforeunload)
+ * - 내부 링크 클릭 (anchor click)
+ * - 브라우저 뒤로가기 (popstate)
+ *
+ * POPSTATE 이탈 시 history.go() 대신 router.push(previousUrl)로 이동하여
+ * Next.js App Router와 호환성을 보장한다.
+ */
+export function usePreventNavigation(isDirty: boolean) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [isBlocking, setIsBlocking] = useState(false);
+  const isDirtyRef = useRef(isDirty);
+  const pendingActionRef = useRef<(() => void) | null>(null);
+
+  isDirtyRef.current = isDirty;
+
+  useEffect(() => {
+    if (!isDirty) return;
+    if (history.state?.blocked !== true) {
+      history.pushState({ blocked: true }, '', location.href);
+    }
+  }, [isDirty]);
+
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (!isDirtyRef.current) return;
+      e.preventDefault();
+    };
+
+    const handleAnchorClick = (e: MouseEvent) => {
+      if (!isDirtyRef.current) return;
+      const anchor = (e.target as HTMLElement).closest('a');
+      if (anchor && anchor.href.startsWith(location.origin) && !anchor.target) {
+        e.preventDefault();
+        const href = anchor.href;
+        pendingActionRef.current = () => {
+          location.href = href;
+        };
+        setIsBlocking(true);
+      }
+    };
+
+    const handlePopState = () => {
+      if (!isDirtyRef.current) return;
+      history.pushState({ blocked: true }, '', location.href);
+      setTimeout(() => {
+        pendingActionRef.current = () => {
+          router.push(getPreviousUrl());
+        };
+        setIsBlocking(true);
+      }, 0);
+    };
+
+    addEventListener('beforeunload', handleBeforeUnload);
+    addEventListener('click', handleAnchorClick, true);
+    addEventListener('popstate', handlePopState);
+
+    return () => {
+      removeEventListener('beforeunload', handleBeforeUnload);
+      removeEventListener('click', handleAnchorClick, true);
+      removeEventListener('popstate', handlePopState);
+    };
+  }, [router, pathname]);
+
+  const onStay = useCallback(() => {
+    pendingActionRef.current = null;
+    setIsBlocking(false);
+  }, []);
+
+  const onLeave = useCallback(() => {
+    isDirtyRef.current = false;
+    setIsBlocking(false);
+    const action = pendingActionRef.current;
+    pendingActionRef.current = null;
+    action?.();
+  }, []);
+
+  return { isBlocking, onStay, onLeave };
+}

--- a/src/features/survey/hooks/usePreventNavigation.ts
+++ b/src/features/survey/hooks/usePreventNavigation.ts
@@ -42,7 +42,7 @@ export function usePreventNavigation(isDirty: boolean) {
         e.preventDefault();
         const href = anchor.href;
         pendingActionRef.current = () => {
-          location.href = href;
+          router.push(href);
         };
         setIsBlocking(true);
       }
@@ -53,7 +53,7 @@ export function usePreventNavigation(isDirty: boolean) {
       history.pushState({ blocked: true }, '', location.href);
       setTimeout(() => {
         pendingActionRef.current = () => {
-          router.push(getPreviousUrl());
+          router.replace(getPreviousUrl());
         };
         setIsBlocking(true);
       }, 0);

--- a/src/features/survey/hooks/useSurveyForm.ts
+++ b/src/features/survey/hooks/useSurveyForm.ts
@@ -74,7 +74,7 @@ function profileToFormValues(p: Profile): SurveyFormValues {
     barrier_free: p.is_barrier_free,
     disability_type: p.disability_type,
     disability_level: p.disability_level,
-    mobility: p.mobility ?? '',
+    mobility: p.mobility,
     hand_usage: p.hand_usage,
     stamina: p.stamina,
     communication: p.communication,
@@ -100,6 +100,7 @@ export function useSurveyForm(mode: 'create' | 'edit' = 'create') {
   const queryClient = useQueryClient();
   const [step, setStep] = useState<1 | 2>(1);
   const [values, setValues] = useState<SurveyFormValues>(INITIAL);
+  const [initialValues, setInitialValues] = useState<SurveyFormValues>(INITIAL);
   const [errors, setErrors] = useState<FormErrors>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isComplete, setIsComplete] = useState(false);
@@ -113,7 +114,9 @@ export function useSurveyForm(mode: 'create' | 'edit' = 'create') {
 
   useEffect(() => {
     if (mode === 'edit' && existingProfile && !initialized) {
-      setValues(profileToFormValues(existingProfile));
+      const editValues = profileToFormValues(existingProfile);
+      setValues(editValues);
+      setInitialValues(editValues);
       setInitialized(true);
     }
   }, [mode, existingProfile, initialized]);
@@ -255,6 +258,9 @@ export function useSurveyForm(mode: 'create' | 'edit' = 'create') {
     router.push('/profile');
   }
 
+  const isDirty =
+    !isComplete && JSON.stringify(values) !== JSON.stringify(initialValues);
+
   return {
     mode,
     step,
@@ -262,6 +268,7 @@ export function useSurveyForm(mode: 'create' | 'edit' = 'create') {
     errors,
     isSubmitting,
     isComplete,
+    isDirty,
     setField,
     onPrimarySidoChange,
     onSecondarySidoChange,

--- a/src/features/survey/ui/SurveyForm.tsx
+++ b/src/features/survey/ui/SurveyForm.tsx
@@ -10,6 +10,7 @@ type Props = {
   errors: Partial<Record<keyof SurveyFormValues, string>>;
   isSubmitting: boolean;
   isComplete: boolean;
+  isBlocking: boolean;
   sigunguList: { primary: string[]; secondary: string[] };
   setField: <K extends keyof SurveyFormValues>(
     key: K,
@@ -23,6 +24,8 @@ type Props = {
   onPrevStep: () => void;
   onSubmit: () => void;
   onCompleteConfirm: () => void;
+  onStay: () => void;
+  onLeave: () => void;
 };
 
 export function SurveyForm({
@@ -32,6 +35,7 @@ export function SurveyForm({
   errors,
   isSubmitting,
   isComplete,
+  isBlocking,
   sigunguList,
   setField,
   onPrimarySidoChange,
@@ -42,6 +46,8 @@ export function SurveyForm({
   onPrevStep,
   onSubmit,
   onCompleteConfirm,
+  onStay,
+  onLeave,
 }: Props) {
   const isEdit = mode === 'edit';
 
@@ -116,6 +122,23 @@ export function SurveyForm({
           cancelLabel="닫기"
           onConfirm={onCompleteConfirm}
           onClose={onCompleteConfirm}
+        />
+      )}
+
+      {isBlocking && (
+        <ConfirmModal
+          title="페이지를 이동하시겠어요?"
+          description={
+            <>
+              폼 작성을 그만하고 이동할까요?
+              <br />
+              작성 중인 내용은 저장되지 않아요.
+            </>
+          }
+          confirmLabel="이동하기"
+          cancelLabel="머무르기"
+          onConfirm={onLeave}
+          onClose={onStay}
         />
       )}
     </div>

--- a/src/shared/providers/NavigationTracker.tsx
+++ b/src/shared/providers/NavigationTracker.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+import { pushUrlHistory } from '@/shared/utils/urlHistory';
+
+export function NavigationTracker() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    pushUrlHistory(pathname);
+  }, [pathname]);
+
+  return null;
+}

--- a/src/shared/types/profile.ts
+++ b/src/shared/types/profile.ts
@@ -9,7 +9,7 @@ export const CreateProfileBodySchema = z.object({
   is_barrier_free: z.boolean(),
   disability_type: z.string().min(1),
   disability_level: z.string().min(1),
-  mobility: z.string().optional(),
+  mobility: z.string().min(1),
   hand_usage: z.string().min(1),
   stamina: z.string().min(1),
   communication: z.string().min(1),
@@ -30,7 +30,7 @@ export type Profile = {
   is_barrier_free: boolean;
   disability_type: string;
   disability_level: string;
-  mobility: string | null;
+  mobility: string;
   hand_usage: string;
   stamina: string;
   communication: string;

--- a/src/shared/types/user.ts
+++ b/src/shared/types/user.ts
@@ -1,6 +1,4 @@
-// DevStatePanel / mockData에서 사용 중인 레거시 타입 — 실제 API 연동 후 제거
 export type UserState = 'guest' | 'loggedIn' | 'surveyed';
-export type UserProfile = { name: string; lastSurveyDate: string };
 
 // Supabase users 테이블과 1:1 대응
 export type User = {

--- a/src/shared/types/userProfile.ts
+++ b/src/shared/types/userProfile.ts
@@ -1,4 +1,4 @@
-export type ChildProfile = {
+export type UserProfile = {
   name: string;
   age: number;
   gender: '남성' | '여성';

--- a/src/shared/ui/AIResultCard/AIResultCard.tsx
+++ b/src/shared/ui/AIResultCard/AIResultCard.tsx
@@ -3,14 +3,14 @@ import { FitBadge } from '@/shared/ui/FitBadge';
 import { PersonalityRadarChart } from '@/shared/ui/PersonalityRadarChart';
 
 type AIResultCardProps = {
-  childName: string;
+  userName: string;
   axes: PersonalityAxis[];
   summary: string;
   jobs: MatchedJob[];
 };
 
 export function AIResultCard({
-  childName,
+  userName,
   axes,
   summary,
   jobs,
@@ -22,7 +22,7 @@ export function AIResultCard({
         {/* 좌: 레이더 차트 */}
         <div className="flex flex-col items-center p-6">
           <h3 className="mb-6 w-full border-l-[3px] border-primary pl-[10px] text-[1rem] font-semibold leading-[1.5] text-gray-900">
-            {childName}님의 직업 성향
+            {userName}님의 직업 성향
           </h3>
           <PersonalityRadarChart data={axes} />
         </div>
@@ -30,7 +30,7 @@ export function AIResultCard({
         {/* 우: 맞는 직종 TOP 3 */}
         <div className="p-6">
           <h3 className="mb-6 border-l-[3px] border-primary pl-[10px] text-[1rem] font-semibold leading-[1.5] text-gray-900">
-            {childName}님에게 맞는 직종 TOP 3
+            {userName}님에게 맞는 직종 TOP 3
           </h3>
           <ol className="flex flex-col gap-3" aria-label="매칭 직종 목록">
             {jobs.map((job, index) => (

--- a/src/shared/ui/ConfirmModal/ConfirmModal.tsx
+++ b/src/shared/ui/ConfirmModal/ConfirmModal.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/shared/ui/Button';
 
 type ConfirmModalProps = {
   title: string;
-  description: string;
+  description: React.ReactNode;
   confirmLabel: string;
   cancelLabel?: string;
   variant?: 'default' | 'destructive';

--- a/src/shared/ui/MatchedJobsCard/MatchedJobsCard.tsx
+++ b/src/shared/ui/MatchedJobsCard/MatchedJobsCard.tsx
@@ -2,15 +2,15 @@ import type { MatchedJob } from '@/shared/types/job';
 import { FitBadge } from '@/shared/ui/FitBadge';
 
 type MatchedJobsCardProps = {
-  childName: string;
+  userName: string;
   jobs: MatchedJob[];
 };
 
-export function MatchedJobsCard({ childName, jobs }: MatchedJobsCardProps) {
+export function MatchedJobsCard({ userName, jobs }: MatchedJobsCardProps) {
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-6">
       <h3 className="mb-6 border-l-[3px] border-primary pl-[10px] text-[1rem] font-semibold leading-[1.5] text-gray-900">
-        {childName}님에게 맞는 직종 TOP 3
+        {userName}님에게 맞는 직종 TOP 3
       </h3>
       <ol className="flex flex-col gap-3" aria-label="매칭 직종 목록">
         {jobs.map((job, index) => (

--- a/src/shared/ui/PersonalitySummaryCard/PersonalitySummaryCard.tsx
+++ b/src/shared/ui/PersonalitySummaryCard/PersonalitySummaryCard.tsx
@@ -2,20 +2,20 @@ import type { PersonalityAxis } from '@/shared/types/job';
 import { PersonalityRadarChart } from '@/shared/ui/PersonalityRadarChart';
 
 type PersonalitySummaryCardProps = {
-  childName: string;
+  userName: string;
   axes: PersonalityAxis[];
   summary: string;
 };
 
 export function PersonalitySummaryCard({
-  childName,
+  userName,
   axes,
   summary,
 }: PersonalitySummaryCardProps) {
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-6">
       <h3 className="mb-6 border-l-[3px] border-primary pl-[10px] text-[1rem] font-semibold leading-[1.5] text-gray-900">
-        {childName}님의 직업 성향
+        {userName}님의 직업 성향
       </h3>
       <div className="flex flex-col items-center gap-6 md:flex-row md:items-start">
         <PersonalityRadarChart data={axes} />

--- a/src/shared/utils/mockData.ts
+++ b/src/shared/utils/mockData.ts
@@ -3,15 +3,9 @@ import type {
   JobPosting,
   PersonalityAxis,
 } from '@/shared/types/job';
-import type { UserProfile } from '@/shared/types/user';
-import type { ChildProfile } from '@/shared/types/childProfile';
+import type { UserProfile } from '@/shared/types/userProfile';
 
 export const MOCK_USER_PROFILE: UserProfile = {
-  name: '민준',
-  lastSurveyDate: '2026.04.10',
-};
-
-export const MOCK_CHILD_PROFILE: ChildProfile = {
   name: '민준',
   age: 17,
   gender: '남성',

--- a/src/shared/utils/urlHistory.ts
+++ b/src/shared/utils/urlHistory.ts
@@ -1,0 +1,22 @@
+const KEY = 'url-history';
+const MAX = 3;
+
+function getUrlHistory(): string[] {
+  try {
+    return JSON.parse(sessionStorage.getItem(KEY) ?? '[]') as string[];
+  } catch {
+    return [];
+  }
+}
+
+export function pushUrlHistory(url: string) {
+  const history = getUrlHistory();
+  if (history[history.length - 1] === url) return;
+  const next = [...history, url].slice(-MAX);
+  sessionStorage.setItem(KEY, JSON.stringify(next));
+}
+
+export function getPreviousUrl(): string {
+  const history = getUrlHistory();
+  return history.length >= 2 ? (history[history.length - 2] ?? '/') : '/';
+}


### PR DESCRIPTION
Closes #68

## 변경 내용

### 1. ChildProfile → UserProfile 리네이밍

서비스 대상을 child로 한정하지 않는 방향으로 전체 네이밍을 정리했습니다.

- `childProfile.ts` → `userProfile.ts`, `ChildProfile` → `UserProfile` 타입 교체
- `childProfile` 변수/prop → `userProfile`, `childName` prop → `userName` 전체 수정
- `MOCK_CHILD_PROFILE` → `MOCK_USER_PROFILE` 통합, `user.ts`의 레거시 `UserProfile` 제거
- `mobility` 타입 `string | null` → `string` 수정 (라디오 선택 필드라 null이 될 수 없음)

**변경 파일**
`shared/types/userProfile.ts` (신규, childProfile.ts 대체) · `shared/types/profile.ts` · `shared/types/user.ts` · `shared/utils/mockData.ts` · `features/profile/hooks/useProfile.ts` · `features/profile/ui/ProfileView.tsx` · `features/profile/ui/ProfileInfoTab.tsx` · `features/dashboard/hooks/useDashboard.ts` · `features/dashboard/ui/DashboardView.tsx` · `features/dashboard/ui/JobListSection.tsx` · `shared/ui/AIResultCard` · `shared/ui/PersonalitySummaryCard` · `shared/ui/MatchedJobsCard`

---

### 2. Survey 폼 이탈 방지

폼 작성 중 이탈 시도 시 커스텀 모달을 띄워 실수로 인한 데이터 유실을 방지합니다.

**차단 대상**
- 새로고침 / 탭 닫기 (`beforeunload`)
- 내부 링크 클릭 (anchor click)
- 브라우저 뒤로가기 (`popstate`)

**구현 방식**

| 파일 | 역할 |
|---|---|
| `shared/utils/urlHistory.ts` | sessionStorage에 최근 방문 URL 최대 3개 스택으로 저장 |
| `shared/providers/NavigationTracker.tsx` | `usePathname` 변경마다 URL 스택 업데이트, layout에 마운트 |
| `features/survey/hooks/usePreventNavigation.ts` | 이탈 차단 훅, `{ isBlocking, onStay, onLeave }` 반환 |

POPSTATE 이탈 확인 시 `history.go(-n)` 대신 `router.push(getPreviousUrl())`을 사용하여 Next.js App Router와의 호환성을 보장합니다.

**모달 UI**
- 버튼: 머무르기 / 이동하기
- anchor click 이탈 후 "이동하기" 클릭 시 브라우저 기본 모달 중복 표시 방지 (`isDirtyRef.current = false` 처리)