### PR TITLE
feat: 장애 유형 다중 선택(체크박스) 전환 및 기타 입력 추가 #74

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,7 +302,7 @@ create table profiles (
   region_primary    text        not null,
   region_secondary  text,
   is_barrier_free   boolean     not null default false,
-  disability_type   text        not null,
+  disability_type   text[]      not null default '{}',
   disability_level  text        not null,
   mobility          text        not null,
   hand_usage        text        not null,

--- a/docs/AI_match_guide.md
+++ b/docs/AI_match_guide.md
@@ -68,7 +68,7 @@ export const {name}Strategy: MatchStrategy = {
   region_primary: '서울특별시 강남구', // 희망 지역 1순위
   region_secondary: '서울특별시 마포구' | null, // 희망 지역 2순위
   is_barrier_free: false,       // 베리어프리 필요 여부
-  disability_type: '지적장애',   // 장애 유형
+  disability_type: ['지적장애'],  // 장애 유형 (복수 선택 가능)
   disability_level: '중등도',    // 장애 등급
   mobility: '자유로움',          // 이동 능력
   hand_usage: '세밀한 작업 가능',  // 손 사용
@@ -140,7 +140,7 @@ buildMessages: (profile) => ({
 ...`,
   user: `다음 사용자의 프로필을 분석해줘:
 이름: ${profile.name}
-장애 유형: ${profile.disability_type}
+장애 유형: ${profile.disability_type.join(', ')}
 ...`,
 })
 ```

--- a/src/app/survey/page.tsx
+++ b/src/app/survey/page.tsx
@@ -26,6 +26,7 @@ function SurveyContent() {
       onPrimarySidoChange={form.onPrimarySidoChange}
       onSecondarySidoChange={form.onSecondarySidoChange}
       onSecondaryReset={form.onSecondaryReset}
+      onDisabilityTypeChange={form.onDisabilityTypeChange}
       onHopeActivitiesChange={form.onHopeActivitiesChange}
       onNextStep={form.onNextStep}
       onPrevStep={form.onPrevStep}

--- a/src/features/profile/hooks/useProfile.ts
+++ b/src/features/profile/hooks/useProfile.ts
@@ -24,7 +24,7 @@ function toUserProfile(p: Profile): UserProfile {
     region1: parseRegion(p.region_primary),
     region2: p.region_secondary ? parseRegion(p.region_secondary) : undefined,
     barrierFree: p.is_barrier_free,
-    disabilityType: p.disability_type as UserProfile['disabilityType'],
+    disabilityType: p.disability_type,
     disabilityGrade: p.disability_level as UserProfile['disabilityGrade'],
     mobility: p.mobility as UserProfile['mobility'],
     handUse: p.hand_usage as UserProfile['handUse'],

--- a/src/features/profile/ui/ProfileInfoTab.tsx
+++ b/src/features/profile/ui/ProfileInfoTab.tsx
@@ -13,15 +13,16 @@ type ProfileInfoTabProps = {
   onEdit: () => void;
 };
 
-type InfoRowProps = { label: string; value: string };
+type InfoRowProps = { label: string; value: string | string[] };
 
 function InfoRow({ label, value }: InfoRowProps) {
+  const display = Array.isArray(value) ? value.join(', ') : value;
   return (
     <div className="flex gap-4 py-2.5 border-b border-gray-100 last:border-b-0">
       <dt className="w-[140px] shrink-0 text-[0.875rem] text-gray-500">
         {label}
       </dt>
-      <dd className="text-[0.875rem] text-gray-900">{value}</dd>
+      <dd className="text-[0.875rem] text-gray-900">{display}</dd>
     </div>
   );
 }

--- a/src/features/survey/__tests__/surveyApi.test.ts
+++ b/src/features/survey/__tests__/surveyApi.test.ts
@@ -12,7 +12,7 @@ const body = {
   education: '고등학교 졸업',
   region_primary: '서울특별시 강남구',
   is_barrier_free: false,
-  disability_type: '지체',
+  disability_type: ['지체'],
   disability_level: '3급',
   mobility: '자유로움',
   hand_usage: '양손 가능',

--- a/src/features/survey/hooks/useSurveyForm.ts
+++ b/src/features/survey/hooks/useSurveyForm.ts
@@ -5,6 +5,10 @@ import { useRouter } from 'next/navigation';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getSigunguList } from '../utils/regions';
 import { step1Schema, step2Schema } from '../utils/schema';
+import {
+  DISABILITY_TYPE_VALUES,
+  HOPE_ACTIVITIES_VALUES,
+} from '../utils/options';
 import { submitSurvey } from '../api/surveyApi';
 import { getProfile } from '@/features/profile/api/profileApi';
 import type { Profile } from '@/shared/types/profile';
@@ -53,6 +57,18 @@ const INITIAL: SurveyFormValues = {
   hope_activities_other: '',
 };
 
+// 저장된 배열에서 선택지에 없는 커스텀 값을 찾아 반환
+function extractOther(values: string[], knownSet: Set<string>): string {
+  return values.find((v) => !knownSet.has(v)) ?? '';
+}
+
+// 커스텀 값을 '기타'로 치환해서 체크박스 상태에 맞는 배열로 복원
+function restoreOther(values: string[], knownSet: Set<string>): string[] {
+  const hasCustom = values.some((v) => !knownSet.has(v));
+  const known = values.filter((v) => knownSet.has(v));
+  return hasCustom ? [...known, '기타'] : known;
+}
+
 function profileToFormValues(p: Profile): SurveyFormValues {
   const [primarySido = '', ...primaryRest] = p.region_primary.split(' ');
   const primarySigungu = primaryRest.join(' ');
@@ -74,16 +90,22 @@ function profileToFormValues(p: Profile): SurveyFormValues {
     region_secondary_sido: secondarySido,
     region_secondary_sigungu: secondarySigungu,
     barrier_free: p.is_barrier_free,
-    disability_type: p.disability_type,
-    disability_type_other: '',
+    disability_type: restoreOther(p.disability_type, DISABILITY_TYPE_VALUES),
+    disability_type_other: extractOther(
+      p.disability_type,
+      DISABILITY_TYPE_VALUES,
+    ),
     disability_level: p.disability_level,
     mobility: p.mobility,
     hand_usage: p.hand_usage,
     stamina: p.stamina,
     communication: p.communication,
     instruction_level: p.instruction_level,
-    hope_activities: p.hope_activities,
-    hope_activities_other: '',
+    hope_activities: restoreOther(p.hope_activities, HOPE_ACTIVITIES_VALUES),
+    hope_activities_other: extractOther(
+      p.hope_activities,
+      HOPE_ACTIVITIES_VALUES,
+    ),
   };
 }
 
@@ -160,6 +182,21 @@ export function useSurveyForm(mode: 'create' | 'edit' = 'create') {
       region_secondary_sido: undefined,
       region_secondary_sigungu: undefined,
     }));
+  }
+
+  function onDisabilityTypeChange(value: string, checked: boolean) {
+    setValues((prev) => {
+      const next = checked
+        ? [...prev.disability_type, value]
+        : prev.disability_type.filter((v) => v !== value);
+      return {
+        ...prev,
+        disability_type: next,
+        disability_type_other:
+          value === '기타' && !checked ? '' : prev.disability_type_other,
+      };
+    });
+    setErrors((prev) => ({ ...prev, disability_type: undefined }));
   }
 
   function onHopeActivitiesChange(next: string | string[]) {
@@ -284,6 +321,7 @@ export function useSurveyForm(mode: 'create' | 'edit' = 'create') {
     onPrimarySidoChange,
     onSecondarySidoChange,
     onSecondaryReset,
+    onDisabilityTypeChange,
     onHopeActivitiesChange,
     onNextStep,
     onPrevStep,

--- a/src/features/survey/hooks/useSurveyForm.ts
+++ b/src/features/survey/hooks/useSurveyForm.ts
@@ -18,7 +18,8 @@ export type SurveyFormValues = {
   region_secondary_sido: string;
   region_secondary_sigungu: string;
   barrier_free: boolean;
-  disability_type: string;
+  disability_type: string[];
+  disability_type_other: string;
   disability_level: string;
   mobility: string;
   hand_usage: string;
@@ -40,7 +41,8 @@ const INITIAL: SurveyFormValues = {
   region_secondary_sido: '',
   region_secondary_sigungu: '',
   barrier_free: false,
-  disability_type: '',
+  disability_type: [],
+  disability_type_other: '',
   disability_level: '',
   mobility: '',
   hand_usage: '',
@@ -73,6 +75,7 @@ function profileToFormValues(p: Profile): SurveyFormValues {
     region_secondary_sigungu: secondarySigungu,
     barrier_free: p.is_barrier_free,
     disability_type: p.disability_type,
+    disability_type_other: '',
     disability_level: p.disability_level,
     mobility: p.mobility,
     hand_usage: p.hand_usage,
@@ -199,6 +202,7 @@ export function useSurveyForm(mode: 'create' | 'edit' = 'create') {
   async function onSubmit() {
     const result = step2Schema.safeParse({
       disability_type: values.disability_type,
+      disability_type_other: values.disability_type_other,
       disability_level: values.disability_level,
       mobility: values.mobility,
       hand_usage: values.hand_usage,
@@ -216,6 +220,13 @@ export function useSurveyForm(mode: 'create' | 'edit' = 'create') {
 
     setIsSubmitting(true);
     try {
+      const disabilityTypes = values.disability_type.includes('기타')
+        ? [
+            ...values.disability_type.filter((t) => t !== '기타'),
+            values.disability_type_other.trim(),
+          ]
+        : values.disability_type;
+
       const activities = values.hope_activities.includes('기타')
         ? [
             ...values.hope_activities.filter((a) => a !== '기타'),
@@ -235,7 +246,7 @@ export function useSurveyForm(mode: 'create' | 'edit' = 'create') {
         region_primary: `${values.region_primary_sido} ${values.region_primary_sigungu}`,
         region_secondary: regionSecondary,
         is_barrier_free: values.barrier_free,
-        disability_type: values.disability_type,
+        disability_type: disabilityTypes,
         disability_level: values.disability_level,
         mobility: values.mobility,
         hand_usage: values.hand_usage,

--- a/src/features/survey/ui/SurveyForm.tsx
+++ b/src/features/survey/ui/SurveyForm.tsx
@@ -19,6 +19,7 @@ type Props = {
   onPrimarySidoChange: (sido: string) => void;
   onSecondarySidoChange: (sido: string) => void;
   onSecondaryReset: () => void;
+  onDisabilityTypeChange: (value: string, checked: boolean) => void;
   onHopeActivitiesChange: (v: string | string[]) => void;
   onNextStep: () => void;
   onPrevStep: () => void;
@@ -41,6 +42,7 @@ export function SurveyForm({
   onPrimarySidoChange,
   onSecondarySidoChange,
   onSecondaryReset,
+  onDisabilityTypeChange,
   onHopeActivitiesChange,
   onNextStep,
   onPrevStep,
@@ -103,6 +105,7 @@ export function SurveyForm({
           values={values}
           errors={errors}
           setField={setField}
+          onDisabilityTypeChange={onDisabilityTypeChange}
           onHopeActivitiesChange={onHopeActivitiesChange}
           onPrevStep={onPrevStep}
           onSubmit={onSubmit}

--- a/src/features/survey/ui/SurveyForm.tsx
+++ b/src/features/survey/ui/SurveyForm.tsx
@@ -58,7 +58,7 @@ export function SurveyForm({
         {isEdit ? '검사 내용 수정' : '특성 검사'}
       </h1>
       <p className="mb-8 text-[0.9375rem] text-gray-500">
-        장애 정보와 특성을 입력하면 AI가 적합한 직종과 채용공고를 찾아드려요
+        특성을 알려주시면 AI가 맞는 직종과 채용공고를 찾아드려요
       </p>
 
       {/* 스텝 인디케이터 */}
@@ -68,7 +68,7 @@ export function SurveyForm({
             Step {step} / 2
           </span>
           <span className="text-[0.8125rem] text-gray-500">
-            {step === 1 ? '기본 정보' : '장애 정보'}
+            {step === 1 ? '기본 정보' : '세부 정보'}
           </span>
         </div>
         <div
@@ -114,9 +114,15 @@ export function SurveyForm({
         <ConfirmModal
           title={isEdit ? '수정 완료' : '검사 완료'}
           description={
-            isEdit
-              ? '검사 내용이 수정되었습니다! 결과를 확인해보세요.'
-              : '검사가 완료되었습니다! 결과를 확인해보세요.'
+            isEdit ? (
+              <>
+                프로필이 수정되었어요.
+                <br />
+                변경된 내용에 맞춰 AI 결과도 업데이트돼요.
+              </>
+            ) : (
+              '검사가 완료되었습니다! 결과를 확인해보세요.'
+            )
           }
           confirmLabel="결과 보기"
           cancelLabel="닫기"

--- a/src/features/survey/ui/SurveyStep2.tsx
+++ b/src/features/survey/ui/SurveyStep2.tsx
@@ -103,7 +103,7 @@ export function SurveyStep2({
           id="step2-heading"
           className="text-[1rem] font-semibold text-gray-900"
         >
-          장애 정보
+          나의 특성
         </h2>
         <p className="mt-1 text-[0.875rem] text-gray-500">
           신체 조건과 희망 활동을 알려주세요
@@ -112,18 +112,42 @@ export function SurveyStep2({
 
       <div className="flex flex-col gap-8">
         {/* 장애 유형 */}
-        <RadioGroup label="장애 유형" required error={errors.disability_type}>
+        <CheckboxGroup
+          label="장애 유형"
+          required
+          error={errors.disability_type}
+        >
           {DISABILITY_TYPE_OPTIONS.map((opt) => (
-            <Radio
+            <Checkbox
               key={opt.value}
-              name="disability_type"
-              value={opt.value}
+              id={`disability_type-${opt.value}`}
               label={opt.label}
-              checked={values.disability_type === opt.value}
-              onChange={() => setField('disability_type', opt.value)}
+              checked={values.disability_type.includes(opt.value)}
+              onChange={(e) => {
+                const next = e.target.checked
+                  ? [...values.disability_type, opt.value]
+                  : values.disability_type.filter((v) => v !== opt.value);
+                setField('disability_type', next);
+                if (opt.value === '기타' && !e.target.checked) {
+                  setField('disability_type_other', '');
+                }
+              }}
             />
           ))}
-        </RadioGroup>
+        </CheckboxGroup>
+
+        {/* 장애 유형 — 기타 내용 */}
+        {values.disability_type.includes('기타') && (
+          <Input
+            label="기타 장애 유형"
+            required
+            value={values.disability_type_other}
+            onChange={(e) => setField('disability_type_other', e.target.value)}
+            error={errors.disability_type_other}
+            placeholder="장애 유형을 입력해주세요"
+            maxLength={100}
+          />
+        )}
 
         {/* 장애 등급 */}
         <RadioGroup
@@ -239,6 +263,7 @@ export function SurveyStep2({
           {HOPE_ACTIVITIES_OPTIONS.map((opt) => (
             <Checkbox
               key={opt.value}
+              id={`hope_activities-${opt.value}`}
               label={opt.label}
               checked={values.hope_activities.includes(opt.value)}
               onChange={(e) =>

--- a/src/features/survey/ui/SurveyStep2.tsx
+++ b/src/features/survey/ui/SurveyStep2.tsx
@@ -3,66 +3,16 @@ import { Checkbox, CheckboxGroup } from '@/shared/ui/Checkbox';
 import { Input } from '@/shared/ui/Input';
 import { Radio, RadioGroup } from '@/shared/ui/Radio';
 import type { SurveyFormValues } from '../hooks/useSurveyForm';
-
-const DISABILITY_TYPE_OPTIONS = [
-  { value: '시각장애', label: '시각장애' },
-  { value: '청각장애', label: '청각장애' },
-  { value: '지체장애', label: '지체장애' },
-  { value: '언어장애', label: '언어장애' },
-  { value: '안면장애', label: '안면장애' },
-  { value: '지적장애', label: '지적장애' },
-  { value: '자폐성장애', label: '자폐성장애' },
-  { value: '기타', label: '기타' },
-];
-
-const DISABILITY_LEVEL_OPTIONS = [
-  { value: '장애의 정도가 심함', label: '장애의 정도가 심함' },
-  { value: '장애의 정도가 심하지 않음', label: '장애의 정도가 심하지 않음' },
-  { value: '모르겠어요', label: '모르겠어요' },
-];
-
-const MOBILITY_OPTIONS = [
-  { value: '자유로움', label: '자유로움' },
-  { value: '보조기구 사용', label: '보조기구 사용' },
-  { value: '휠체어 사용', label: '휠체어 사용' },
-];
-
-const HAND_USAGE_OPTIONS = [
-  { value: '세밀한 작업 가능', label: '세밀한 작업 가능' },
-  { value: '큰 동작만 가능', label: '큰 동작만 가능' },
-  { value: '어려움', label: '어려움' },
-];
-
-const STAMINA_OPTIONS = [
-  { value: '4시간 이상 활동 가능', label: '4시간 이상' },
-  { value: '2~4시간', label: '2~4시간' },
-  { value: '2시간 미만', label: '2시간 미만' },
-];
-
-const COMMUNICATION_OPTIONS = [
-  { value: '일상 대화 가능', label: '일상 대화 가능' },
-  { value: '짧은 문장 가능', label: '짧은 문장 가능' },
-  { value: '단어 수준', label: '단어 수준' },
-  { value: '비언어적 소통', label: '비언어적 소통' },
-];
-
-const INSTRUCTION_LEVEL_OPTIONS = [
-  { value: '복잡한 지시 이해', label: '복잡한 지시 이해' },
-  { value: '2단계 지시 이해', label: '2단계 지시 이해' },
-  { value: '단순 지시만 가능', label: '단순 지시만 가능' },
-  { value: '시범 보여주면 가능', label: '시범 보여주면 가능' },
-];
-
-const HOPE_ACTIVITIES_OPTIONS = [
-  { value: '같은 일 반복하기', label: '같은 일 반복하기' },
-  { value: '손으로 만들기', label: '손으로 만들기' },
-  { value: '물건 정리·분류', label: '물건 정리·분류' },
-  { value: '몸 움직이기', label: '몸 움직이기' },
-  { value: '컴퓨터·기기 다루기', label: '컴퓨터·기기 다루기' },
-  { value: '동식물 돌보기', label: '동식물 돌보기' },
-  { value: '청소·세탁 등 환경 관리', label: '청소·세탁 등 환경 관리' },
-  { value: '기타', label: '기타' },
-];
+import {
+  DISABILITY_TYPE_OPTIONS,
+  DISABILITY_LEVEL_OPTIONS,
+  MOBILITY_OPTIONS,
+  HAND_USAGE_OPTIONS,
+  STAMINA_OPTIONS,
+  COMMUNICATION_OPTIONS,
+  INSTRUCTION_LEVEL_OPTIONS,
+  HOPE_ACTIVITIES_OPTIONS,
+} from '../utils/options';
 
 type Props = {
   mode: 'create' | 'edit';
@@ -72,6 +22,7 @@ type Props = {
     key: K,
     value: SurveyFormValues[K],
   ) => void;
+  onDisabilityTypeChange: (value: string, checked: boolean) => void;
   onHopeActivitiesChange: (v: string | string[]) => void;
   onPrevStep: () => void;
   onSubmit: () => void;
@@ -83,6 +34,7 @@ export function SurveyStep2({
   values,
   errors,
   setField,
+  onDisabilityTypeChange,
   onHopeActivitiesChange,
   onPrevStep,
   onSubmit,
@@ -123,15 +75,9 @@ export function SurveyStep2({
               id={`disability_type-${opt.value}`}
               label={opt.label}
               checked={values.disability_type.includes(opt.value)}
-              onChange={(e) => {
-                const next = e.target.checked
-                  ? [...values.disability_type, opt.value]
-                  : values.disability_type.filter((v) => v !== opt.value);
-                setField('disability_type', next);
-                if (opt.value === '기타' && !e.target.checked) {
-                  setField('disability_type_other', '');
-                }
-              }}
+              onChange={(e) =>
+                onDisabilityTypeChange(opt.value, e.target.checked)
+              }
             />
           ))}
         </CheckboxGroup>

--- a/src/features/survey/utils/options.ts
+++ b/src/features/survey/utils/options.ts
@@ -1,0 +1,66 @@
+export const DISABILITY_TYPE_OPTIONS = [
+  { value: '시각장애', label: '시각장애' },
+  { value: '청각장애', label: '청각장애' },
+  { value: '지체장애', label: '지체장애' },
+  { value: '언어장애', label: '언어장애' },
+  { value: '안면장애', label: '안면장애' },
+  { value: '지적장애', label: '지적장애' },
+  { value: '자폐성장애', label: '자폐성장애' },
+  { value: '기타', label: '기타' },
+];
+
+export const DISABILITY_LEVEL_OPTIONS = [
+  { value: '장애의 정도가 심함', label: '장애의 정도가 심함' },
+  { value: '장애의 정도가 심하지 않음', label: '장애의 정도가 심하지 않음' },
+  { value: '모르겠어요', label: '모르겠어요' },
+];
+
+export const MOBILITY_OPTIONS = [
+  { value: '자유로움', label: '자유로움' },
+  { value: '보조기구 사용', label: '보조기구 사용' },
+  { value: '휠체어 사용', label: '휠체어 사용' },
+];
+
+export const HAND_USAGE_OPTIONS = [
+  { value: '세밀한 작업 가능', label: '세밀한 작업 가능' },
+  { value: '큰 동작만 가능', label: '큰 동작만 가능' },
+  { value: '어려움', label: '어려움' },
+];
+
+export const STAMINA_OPTIONS = [
+  { value: '4시간 이상 활동 가능', label: '4시간 이상' },
+  { value: '2~4시간', label: '2~4시간' },
+  { value: '2시간 미만', label: '2시간 미만' },
+];
+
+export const COMMUNICATION_OPTIONS = [
+  { value: '일상 대화 가능', label: '일상 대화 가능' },
+  { value: '짧은 문장 가능', label: '짧은 문장 가능' },
+  { value: '단어 수준', label: '단어 수준' },
+  { value: '비언어적 소통', label: '비언어적 소통' },
+];
+
+export const INSTRUCTION_LEVEL_OPTIONS = [
+  { value: '복잡한 지시 이해', label: '복잡한 지시 이해' },
+  { value: '2단계 지시 이해', label: '2단계 지시 이해' },
+  { value: '단순 지시만 가능', label: '단순 지시만 가능' },
+  { value: '시범 보여주면 가능', label: '시범 보여주면 가능' },
+];
+
+export const HOPE_ACTIVITIES_OPTIONS = [
+  { value: '같은 일 반복하기', label: '같은 일 반복하기' },
+  { value: '손으로 만들기', label: '손으로 만들기' },
+  { value: '물건 정리·분류', label: '물건 정리·분류' },
+  { value: '몸 움직이기', label: '몸 움직이기' },
+  { value: '컴퓨터·기기 다루기', label: '컴퓨터·기기 다루기' },
+  { value: '동식물 돌보기', label: '동식물 돌보기' },
+  { value: '청소·세탁 등 환경 관리', label: '청소·세탁 등 환경 관리' },
+  { value: '기타', label: '기타' },
+];
+
+export const DISABILITY_TYPE_VALUES = new Set(
+  DISABILITY_TYPE_OPTIONS.map((o) => o.value),
+);
+export const HOPE_ACTIVITIES_VALUES = new Set(
+  HOPE_ACTIVITIES_OPTIONS.map((o) => o.value),
+);

--- a/src/features/survey/utils/schema.ts
+++ b/src/features/survey/utils/schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { DISABILITY_TYPE_VALUES, HOPE_ACTIVITIES_VALUES } from './options';
 
 export const step1Schema = z
   .object({
@@ -40,8 +41,18 @@ export const step2Schema = z
       }
       return true;
     },
+    { message: '기타 내용을 입력해주세요', path: ['disability_type_other'] },
+  )
+  .refine(
+    (data) => {
+      if (data.disability_type.includes('기타')) {
+        const val = (data.disability_type_other ?? '').trim();
+        return !DISABILITY_TYPE_VALUES.has(val);
+      }
+      return true;
+    },
     {
-      message: '기타 내용을 입력해주세요',
+      message: '이미 선택 가능한 항목이에요. 다른 내용을 입력해주세요',
       path: ['disability_type_other'],
     },
   )
@@ -52,8 +63,18 @@ export const step2Schema = z
       }
       return true;
     },
+    { message: '기타 내용을 입력해주세요', path: ['hope_activities_other'] },
+  )
+  .refine(
+    (data) => {
+      if (data.hope_activities.includes('기타')) {
+        const val = (data.hope_activities_other ?? '').trim();
+        return !HOPE_ACTIVITIES_VALUES.has(val);
+      }
+      return true;
+    },
     {
-      message: '기타 내용을 입력해주세요',
+      message: '이미 선택 가능한 항목이에요. 다른 내용을 입력해주세요',
       path: ['hope_activities_other'],
     },
   );

--- a/src/features/survey/utils/schema.ts
+++ b/src/features/survey/utils/schema.ts
@@ -18,18 +18,33 @@ export const step1Schema = z
 
 export const step2Schema = z
   .object({
-    disability_type: z.string().min(1, '장애 유형을 선택해주세요'),
+    disability_type: z
+      .array(z.string())
+      .min(1, '장애 유형을 1개 이상 선택해주세요'),
     disability_level: z.string().min(1, '장애 등급을 선택해주세요'),
     mobility: z.string().min(1, '이동 방법을 선택해주세요'),
     hand_usage: z.string().min(1, '손 사용 능력을 선택해주세요'),
     stamina: z.string().min(1, '체력을 선택해주세요'),
     communication: z.string().min(1, '말하기 능력을 선택해주세요'),
     instruction_level: z.string().min(1, '지시 이해 수준을 선택해주세요'),
+    disability_type_other: z.string().optional(),
     hope_activities: z
       .array(z.string())
       .min(1, '희망 활동을 1개 이상 선택해주세요'),
     hope_activities_other: z.string().optional(),
   })
+  .refine(
+    (data) => {
+      if (data.disability_type.includes('기타')) {
+        return (data.disability_type_other ?? '').trim().length > 0;
+      }
+      return true;
+    },
+    {
+      message: '기타 내용을 입력해주세요',
+      path: ['disability_type_other'],
+    },
+  )
   .refine(
     (data) => {
       if (data.hope_activities.includes('기타')) {

--- a/src/shared/types/profile.ts
+++ b/src/shared/types/profile.ts
@@ -7,7 +7,7 @@ export const CreateProfileBodySchema = z.object({
   region_primary: z.string().min(1),
   region_secondary: z.string().optional(),
   is_barrier_free: z.boolean(),
-  disability_type: z.string().min(1),
+  disability_type: z.array(z.string()).min(1),
   disability_level: z.string().min(1),
   mobility: z.string().min(1),
   hand_usage: z.string().min(1),
@@ -28,7 +28,7 @@ export type Profile = {
   region_primary: string;
   region_secondary: string | null;
   is_barrier_free: boolean;
-  disability_type: string;
+  disability_type: string[];
   disability_level: string;
   mobility: string;
   hand_usage: string;

--- a/src/shared/types/userProfile.ts
+++ b/src/shared/types/userProfile.ts
@@ -6,7 +6,7 @@ export type UserProfile = {
   region1: { city: string; district: string };
   region2?: { city: string; district: string };
   barrierFree: boolean;
-  disabilityType: '지적장애' | '자폐성장애' | '기타 발달장애';
+  disabilityType: string[];
   disabilityGrade: '경도' | '중등도' | '중도' | '모르겠어요';
   mobility: '자유로움' | '보조기구 사용' | '휠체어 사용';
   handUse: '세밀한 작업 가능' | '큰 동작만 가능' | '어려움';

--- a/src/shared/utils/mockData.ts
+++ b/src/shared/utils/mockData.ts
@@ -13,7 +13,7 @@ export const MOCK_USER_PROFILE: UserProfile = {
   region1: { city: '서울', district: '강남구' },
   region2: { city: '서울', district: '마포구' },
   barrierFree: true,
-  disabilityType: '지적장애',
+  disabilityType: ['지적장애'],
   disabilityGrade: '중등도',
   mobility: '자유로움',
   handUse: '세밀한 작업 가능',


### PR DESCRIPTION
## 개요
장애 유형 필드를 라디오버튼(단일 선택)에서 체크박스(다중 선택)로 전환하고, DB 스키마 변경(text → text[])에 따른 전체 관련 코드를 수정합니다.

## 주요 변경 사항
- **장애 유형 다중 선택 전환**: RadioGroup → CheckboxGroup으로 교체, disability_type 타입 string → string[]
- **기타 입력 추가**: 장애 유형 '기타' 선택 시 직접 입력 인풋 표시 (hope_activities_other 방식 동일 적용)
- **체크박스 id 충돌 버그 수정**: '기타' 체크박스 id가 동일하게 생성되어 두 그룹이 연동되던 문제 해결 (disability_type-기타 / hope_activities-기타로 명시적 id 부여)
- **타입/스키마 전파**: profile.ts, userProfile.ts, schema.ts, mockData.ts 등 disability_type 관련 전체 수정
- **프로필 수정 완료 모달 문구 변경**: "프로필이 수정되었어요. / 변경된 내용에 맞춰 AI 결과도 업데이트돼요."
- **문서 업데이트**: CLAUDE.md DB 스키마, AI_match_guide.md 예시 반영

Closes #74