### PR TITLE
feat: 공고 카드 클릭 시 work24 검색 페이지 연결 #87

### DIFF
--- a/src/app/api/job-postings/route.ts
+++ b/src/app/api/job-postings/route.ts
@@ -164,6 +164,7 @@ function toPosting(
     reqEduc: item.reqEduc ?? '',
     envConditions: ENV_KEYS.map((k) => item[k] as string).filter(Boolean),
     fitLevel: profile && score !== undefined ? toFitLevel(score) : undefined,
+    detailUrl: `https://www.work24.go.kr/wk/a/b/1700/themeEmpInfoSrchList.do?thmaHrplCd=F00036&resultCnt=10&searchMode=Y&currentPageNo=1&pageIndex=1&sortField=DATE&sortOrderBy=DESC&srcKeyword=${encodeURIComponent(item.busplaName ?? '')}`,
     bookmarked: false,
   };
 }

--- a/src/shared/ui/JobCard/JobCard.tsx
+++ b/src/shared/ui/JobCard/JobCard.tsx
@@ -35,6 +35,15 @@ export function JobCard({ job, onBookmarkToggle }: JobCardProps) {
       aria-label={job.title}
       className="relative flex h-full w-full flex-col rounded-lg border border-gray-200 bg-white p-5 transition-ui hover:border-primary-border"
     >
+      {job.detailUrl && (
+        <a
+          href={job.detailUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`${job.title} 상세 보기`}
+          className="absolute inset-0 rounded-lg"
+        />
+      )}
       <header className="flex items-start justify-between gap-3">
         <div className="flex flex-col gap-1.5">
           {job.fitLevel && (
@@ -55,7 +64,7 @@ export function JobCard({ job, onBookmarkToggle }: JobCardProps) {
           onClick={() => onBookmarkToggle(job.id)}
           aria-label={job.bookmarked ? '북마크 해제' : '북마크 추가'}
           aria-pressed={job.bookmarked}
-          className="transition-ui -mr-1 shrink-0 cursor-pointer rounded-sm text-gray-400 hover:text-primary"
+          className="transition-ui relative z-10 -mr-1 shrink-0 cursor-pointer rounded-sm text-gray-400 hover:text-primary"
         >
           {job.bookmarked ? (
             <BookmarkCheck


### PR DESCRIPTION
## 개요
공고 카드 클릭 시 고용24(work24)에서 해당 회사명으로 장애인 채용공고를 검색한 결과 페이지로 새 탭에서 이동

## 주요 변경 사항
- `route.ts`: `toPosting`에 `detailUrl` 필드 추가 — work24 `srcKeyword`에 `busplaName` 주입
- `JobCard.tsx`: 카드 전체에 투명 `<a>` 오버레이 추가, 북마크 버튼은 `z-index`로 독립 동작 유지

Closes #87