### PR TITLE
fix: loading overlay, confirm modal scroll lock and focus trap #93

### DIFF
--- a/src/shared/ui/ConfirmModal/ConfirmModal.tsx
+++ b/src/shared/ui/ConfirmModal/ConfirmModal.tsx
@@ -31,6 +31,16 @@ export function ConfirmModal({
     const modal = modalRef.current;
     if (!modal) return;
 
+    // 스크롤 잠금
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    // 모달 외 요소 포커스 차단
+    const siblings = Array.from(document.body.children).filter(
+      (el) => !el.contains(modal),
+    ) as HTMLElement[];
+    siblings.forEach((el) => el.setAttribute('inert', ''));
+
     const focusableSelectors =
       'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
     const focusableElements =
@@ -61,7 +71,11 @@ export function ConfirmModal({
     };
 
     document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = prevOverflow;
+      siblings.forEach((el) => el.removeAttribute('inert'));
+    };
   }, [onClose]);
 
   return (

--- a/src/shared/ui/LoadingOverlay/LoadingOverlay.tsx
+++ b/src/shared/ui/LoadingOverlay/LoadingOverlay.tsx
@@ -1,8 +1,20 @@
+'use client';
+
+import { useEffect } from 'react';
+
 type Props = {
   message?: string;
 };
 
 export function LoadingOverlay({ message }: Props) {
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, []);
+
   return (
     <div
       className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-white/80"


### PR DESCRIPTION
## 개요
LoadingOverlay와 ConfirmModal이 열려 있을 때 배경 스크롤이 되거나 배경 요소에 포커스가 가는 접근성 문제를 수정했다.

## 주요 변경 사항
- **LoadingOverlay**: `'use client'` 추가 및 마운트 시 `document.body.style.overflow = 'hidden'` 적용, 언마운트 시 복원
- **ConfirmModal**: 마운트 시 body scroll lock 추가
- **ConfirmModal**: `document.body`의 모달 외 형제 요소에 `inert` 속성 부여 → 마우스 클릭·Tab·스크린리더 포커스 모두 차단
- 언마운트 시 scroll 및 `inert` 원복

Closes #93