### PR TITLE
feat: 북마크 기능 개선 및 스크랩 공고 상세 정보 표시 #98

### DIFF
--- a/src/app/api/bookmarks/route.ts
+++ b/src/app/api/bookmarks/route.ts
@@ -1,22 +1,75 @@
 import { createAuthorizedRoute } from '@/shared/api/createAuthorizedRoute';
 import { supabaseFetch } from '@/shared/api/supabaseFetch';
+import { isApiError } from '@/shared/utils/errorGuards';
 
 type BookmarkRow = {
   id: number;
   posting_title: string;
   posting_url: string;
+  company_name: string;
+  deadline: string;
+  fit_level: string;
   created_at: string;
+};
+
+type AddBookmarkBody = {
+  postingTitle: string;
+  postingUrl: string;
+  companyName: string;
+  deadline: string;
+  fitLevel: string;
 };
 
 export const GET = createAuthorizedRoute(async ({ userId }) => {
   const rows = await supabaseFetch<BookmarkRow[]>(
-    `/rest/v1/bookmarks?user_id=eq.${userId}&select=id,posting_title,posting_url,created_at&order=created_at.desc`,
+    `/rest/v1/bookmarks?user_id=eq.${userId}&select=id,posting_title,posting_url,company_name,deadline,fit_level,created_at&order=created_at.desc`,
   );
 
   return rows.map((row) => ({
     id: row.id,
     postingTitle: row.posting_title,
     postingUrl: row.posting_url,
+    companyName: row.company_name,
+    deadline: row.deadline,
+    fitLevel: row.fit_level,
     createdAt: row.created_at,
   }));
+});
+
+export const POST = createAuthorizedRoute<AddBookmarkBody>(
+  async ({ userId, body }) => {
+    try {
+      await supabaseFetch<BookmarkRow[]>('/rest/v1/bookmarks', {
+        method: 'POST',
+        headers: {
+          Prefer: 'resolution=ignore-duplicates,return=representation',
+        },
+        body: JSON.stringify({
+          user_id: userId,
+          posting_title: body!.postingTitle,
+          posting_url: body!.postingUrl,
+          company_name: body!.companyName,
+          deadline: body!.deadline,
+          fit_level: body!.fitLevel,
+        }),
+      });
+    } catch (err) {
+      if (isApiError(err) && err.status === 409) return;
+      throw err;
+    }
+  },
+);
+
+export const DELETE = createAuthorizedRoute(async ({ userId, request }) => {
+  const { searchParams } = new URL(request.url);
+  const postingUrl = searchParams.get('postingUrl');
+
+  if (!postingUrl) {
+    throw Object.assign(new Error('postingUrl이 필요합니다.'), { status: 400 });
+  }
+
+  await supabaseFetch(
+    `/rest/v1/bookmarks?user_id=eq.${userId}&posting_url=eq.${encodeURIComponent(postingUrl)}`,
+    { method: 'DELETE' },
+  );
 });

--- a/src/app/api/job-postings/route.ts
+++ b/src/app/api/job-postings/route.ts
@@ -80,9 +80,12 @@ export const GET = createAuthorizedRoute(async ({ userId }) => {
     throw new Error('JOB_API_BASE_URL 또는 JOB_API_KEY 환경변수가 없습니다.');
   }
 
-  const [profileRows, jobXml] = await Promise.all([
+  const [profileRows, bookmarkRows, jobXml] = await Promise.all([
     supabaseFetch<ProfileRow[]>(
       `/rest/v1/profiles?user_id=eq.${userId}&select=mobility,hand_usage,stamina,communication,region_primary`,
+    ),
+    supabaseFetch<{ posting_url: string }[]>(
+      `/rest/v1/bookmarks?user_id=eq.${userId}&select=posting_url`,
     ),
     fetch(
       `${baseUrl}?serviceKey=${encodeURIComponent(serviceKey)}&numOfRows=100&pageNo=1`,
@@ -91,6 +94,7 @@ export const GET = createAuthorizedRoute(async ({ userId }) => {
   ]);
 
   const profile = profileRows[0];
+  const bookmarkedUrls = new Set(bookmarkRows.map((r) => r.posting_url));
   const parsed = parser.parse(jobXml);
   const raw: RawItem | RawItem[] = parsed?.response?.body?.items?.item ?? [];
   const allItems = Array.isArray(raw) ? raw : [raw];
@@ -108,7 +112,7 @@ export const GET = createAuthorizedRoute(async ({ userId }) => {
   if (!profile) {
     return unique
       .slice(0, 20)
-      .map((item) => toPosting(item, undefined, undefined));
+      .map((item) => toPosting(item, undefined, undefined, bookmarkedUrls));
   }
 
   const REGION_ABBR: Record<string, string> = {
@@ -147,14 +151,18 @@ export const GET = createAuthorizedRoute(async ({ userId }) => {
     .sort((a, b) => b.score - a.score)
     .slice(0, 20);
 
-  return sorted.map(({ item, score }) => toPosting(item, profile, score));
+  return sorted.map(({ item, score }) =>
+    toPosting(item, profile, score, bookmarkedUrls),
+  );
 });
 
 function toPosting(
   item: RawItem,
   profile: ProfileRow | undefined,
   score: number | undefined,
+  bookmarkedUrls: Set<string>,
 ) {
+  const detailUrl = `https://www.work24.go.kr/wk/a/b/1700/themeEmpInfoSrchList.do?thmaHrplCd=F00036&resultCnt=10&searchMode=Y&currentPageNo=1&pageIndex=1&sortField=DATE&sortOrderBy=DESC&srcKeyword=${encodeURIComponent(item.busplaName ?? '')}`;
   return {
     id: item.rno,
     companyName: item.busplaName ?? '',
@@ -169,7 +177,7 @@ function toPosting(
     reqEduc: item.reqEduc ?? '',
     envConditions: ENV_KEYS.map((k) => item[k] as string).filter(Boolean),
     fitLevel: profile && score !== undefined ? toFitLevel(score) : undefined,
-    detailUrl: `https://www.work24.go.kr/wk/a/b/1700/themeEmpInfoSrchList.do?thmaHrplCd=F00036&resultCnt=10&searchMode=Y&currentPageNo=1&pageIndex=1&sortField=DATE&sortOrderBy=DESC&srcKeyword=${encodeURIComponent(item.busplaName ?? '')}`,
-    bookmarked: false,
+    detailUrl,
+    bookmarked: bookmarkedUrls.has(detailUrl),
   };
 }

--- a/src/features/dashboard/api/bookmarkApi.ts
+++ b/src/features/dashboard/api/bookmarkApi.ts
@@ -1,0 +1,24 @@
+import { bffFetch } from '@/shared/api/bffFetch';
+
+export const addBookmark = (
+  postingTitle: string,
+  postingUrl: string,
+  companyName: string,
+  deadline: string,
+  fitLevel: string,
+): Promise<void> =>
+  bffFetch<void>('/bookmarks', {
+    method: 'POST',
+    body: JSON.stringify({
+      postingTitle,
+      postingUrl,
+      companyName,
+      deadline,
+      fitLevel,
+    }),
+  });
+
+export const removeBookmark = (postingUrl: string): Promise<void> =>
+  bffFetch<void>(`/bookmarks?postingUrl=${encodeURIComponent(postingUrl)}`, {
+    method: 'DELETE',
+  });

--- a/src/features/dashboard/api/jobPostingsApi.ts
+++ b/src/features/dashboard/api/jobPostingsApi.ts
@@ -1,5 +1,5 @@
 import { bffFetch } from '@/shared/api/bffFetch';
 import type { JobPosting } from '@/shared/types/job';
 
-export const getJobPostings = (): Promise<JobPosting[]> =>
-  bffFetch<JobPosting[]>('/job-postings', { method: 'GET' });
+export const getJobPostings = (signal?: AbortSignal): Promise<JobPosting[]> =>
+  bffFetch<JobPosting[]>('/job-postings', { method: 'GET', signal });

--- a/src/features/dashboard/hooks/useBookmarkToggle.ts
+++ b/src/features/dashboard/hooks/useBookmarkToggle.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import type { JobPosting } from '@/shared/types/job';
+import { addBookmark, removeBookmark } from '../api/bookmarkApi';
+
+export function useBookmarkToggle() {
+  const queryClient = useQueryClient();
+
+  const { mutate } = useMutation({
+    mutationFn: (job: JobPosting) =>
+      job.bookmarked
+        ? removeBookmark(job.detailUrl ?? '')
+        : addBookmark(
+            job.title,
+            job.detailUrl ?? '',
+            job.companyName,
+            job.deadline,
+            job.fitLevel ?? '',
+          ),
+
+    onMutate: async (job) => {
+      await queryClient.cancelQueries({ queryKey: ['job-postings'] });
+
+      const previous = queryClient.getQueryData<JobPosting[]>(['job-postings']);
+
+      queryClient.setQueryData<JobPosting[]>(['job-postings'], (old = []) =>
+        old.map((p) =>
+          p.id === job.id ? { ...p, bookmarked: !p.bookmarked } : p,
+        ),
+      );
+
+      return { previous };
+    },
+
+    onError: (_err, _job, ctx) => {
+      if (ctx?.previous) {
+        queryClient.setQueryData(['job-postings'], ctx.previous);
+      }
+    },
+  });
+
+  return (job: JobPosting) => mutate(job);
+}

--- a/src/features/dashboard/hooks/useJobPostings.ts
+++ b/src/features/dashboard/hooks/useJobPostings.ts
@@ -7,6 +7,7 @@ import { getJobPostings } from '../api/jobPostingsApi';
 export function useJobPostings() {
   return useQuery({
     queryKey: ['job-postings'],
-    queryFn: getJobPostings,
+    queryFn: ({ signal }) => getJobPostings(signal),
+    staleTime: 5 * 60 * 1000,
   });
 }

--- a/src/features/dashboard/ui/DashboardView.tsx
+++ b/src/features/dashboard/ui/DashboardView.tsx
@@ -2,6 +2,7 @@
 
 import { useDashboard } from '../hooks/useDashboard';
 import { useJobPostings } from '../hooks/useJobPostings';
+import { useBookmarkToggle } from '../hooks/useBookmarkToggle';
 import { JobListSection } from './JobListSection';
 import { AIResultCard } from '@/shared/ui/AIResultCard';
 
@@ -9,6 +10,7 @@ export function DashboardView() {
   const { userName, personalityAxes, personalitySummary, matchedJobs } =
     useDashboard();
   const { data: postings = [], isPending: isJobsLoading } = useJobPostings();
+  const handleBookmarkToggle = useBookmarkToggle();
 
   return (
     <div className="py-10 md:py-16">
@@ -32,7 +34,7 @@ export function DashboardView() {
           <JobListSection
             userName={userName}
             postings={postings}
-            onBookmarkToggle={() => {}}
+            onBookmarkToggle={handleBookmarkToggle}
             isLoading={isJobsLoading}
           />
         </section>

--- a/src/features/dashboard/ui/JobListSection.tsx
+++ b/src/features/dashboard/ui/JobListSection.tsx
@@ -7,7 +7,7 @@ import { JobCard } from './JobCard';
 type JobListSectionProps = {
   userName: string;
   postings: JobPosting[];
-  onBookmarkToggle: (id: number) => void;
+  onBookmarkToggle: (job: JobPosting) => void;
   isLoading?: boolean;
 };
 

--- a/src/features/profile/api/bookmarksApi.ts
+++ b/src/features/profile/api/bookmarksApi.ts
@@ -3,3 +3,8 @@ import type { Bookmark } from '@/shared/types/bookmark';
 
 export const getBookmarks = (): Promise<Bookmark[]> =>
   bffFetch<Bookmark[]>('/bookmarks', { method: 'GET' });
+
+export const removeBookmark = (postingUrl: string): Promise<void> =>
+  bffFetch<void>(`/bookmarks?postingUrl=${encodeURIComponent(postingUrl)}`, {
+    method: 'DELETE',
+  });

--- a/src/features/profile/hooks/useBookmarkRemove.ts
+++ b/src/features/profile/hooks/useBookmarkRemove.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import type { Bookmark } from '@/shared/types/bookmark';
+import { removeBookmark } from '../api/bookmarksApi';
+
+export function useBookmarkRemove() {
+  const queryClient = useQueryClient();
+
+  const { mutate } = useMutation({
+    mutationFn: (postingUrl: string) => removeBookmark(postingUrl),
+
+    onMutate: async (postingUrl) => {
+      await queryClient.cancelQueries({ queryKey: ['bookmarks'] });
+
+      const previous = queryClient.getQueryData<Bookmark[]>(['bookmarks']);
+
+      queryClient.setQueryData<Bookmark[]>(['bookmarks'], (old = []) =>
+        old.filter((b) => b.postingUrl !== postingUrl),
+      );
+
+      return { previous };
+    },
+
+    onError: (_err, _url, ctx) => {
+      if (ctx?.previous) {
+        queryClient.setQueryData(['bookmarks'], ctx.previous);
+      }
+    },
+  });
+
+  return (postingUrl: string) => mutate(postingUrl);
+}

--- a/src/features/profile/ui/ProfileView.tsx
+++ b/src/features/profile/ui/ProfileView.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 
 import { useProfile } from '../hooks/useProfile';
 import { useScrapedJobs } from '../hooks/useScrapedJobs';
+import { useBookmarkRemove } from '../hooks/useBookmarkRemove';
 import { ProfileSidebar } from './ProfileSidebar';
 import { ProfileInfoTab } from './ProfileInfoTab';
 import { ProfileEmptyView } from './ProfileEmptyView';
@@ -26,6 +27,7 @@ export function ProfileView() {
     matchedJobs,
   } = useProfile();
   const { data: scrapedJobs = [] } = useScrapedJobs();
+  const handleBookmarkRemove = useBookmarkRemove();
 
   if (isLoading) {
     return (
@@ -69,7 +71,12 @@ export function ProfileView() {
               onEdit={handleEdit}
             />
           ) : (
-            <ScrapedJobsTab jobs={scrapedJobs} />
+            <ScrapedJobsTab
+              jobs={scrapedJobs}
+              onBookmarkToggle={(job) =>
+                handleBookmarkRemove(job.detailUrl ?? '')
+              }
+            />
           )}
         </div>
       </div>

--- a/src/features/profile/ui/ScrapedJobsTab.tsx
+++ b/src/features/profile/ui/ScrapedJobsTab.tsx
@@ -1,13 +1,36 @@
 import Link from 'next/link';
-import { ExternalLink } from 'lucide-react';
 
 import type { Bookmark } from '@/shared/types/bookmark';
+import type { JobPosting } from '@/shared/types/job';
+import { JobCard } from '@/shared/ui/JobCard';
+
+function toJobPosting(bookmark: Bookmark): JobPosting {
+  return {
+    id: bookmark.id,
+    title: bookmark.postingTitle,
+    companyName: bookmark.companyName,
+    location: '',
+    salary: '',
+    deadline: bookmark.deadline,
+    empType: '',
+    reqCareer: '',
+    reqEduc: '',
+    envConditions: [],
+    fitLevel: bookmark.fitLevel || undefined,
+    detailUrl: bookmark.postingUrl,
+    bookmarked: true,
+  };
+}
 
 type ScrapedJobsTabProps = {
   jobs: Bookmark[];
+  onBookmarkToggle: (job: JobPosting) => void;
 };
 
-export function ScrapedJobsTab({ jobs }: ScrapedJobsTabProps) {
+export function ScrapedJobsTab({
+  jobs,
+  onBookmarkToggle,
+}: ScrapedJobsTabProps) {
   return (
     <div className="flex flex-col gap-6">
       <header>
@@ -32,25 +55,16 @@ export function ScrapedJobsTab({ jobs }: ScrapedJobsTabProps) {
           </Link>
         </div>
       ) : (
-        <ul className="flex flex-col gap-3" aria-label="스크랩한 채용공고 목록">
+        <ul
+          className="grid gap-6 sm:grid-cols-2"
+          aria-label="스크랩한 채용공고 목록"
+        >
           {jobs.map((job) => (
             <li key={job.id}>
-              <a
-                href={job.postingUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="transition-ui flex items-center justify-between gap-4 rounded-lg border border-gray-200 bg-white p-4 hover:border-primary-border"
-              >
-                <span className="line-clamp-1 text-[0.9375rem] font-medium text-gray-900">
-                  {job.postingTitle}
-                </span>
-                <ExternalLink
-                  size={16}
-                  strokeWidth={1.5}
-                  className="shrink-0 text-gray-400"
-                  aria-hidden="true"
-                />
-              </a>
+              <JobCard
+                job={toJobPosting(job)}
+                onBookmarkToggle={onBookmarkToggle}
+              />
             </li>
           ))}
         </ul>

--- a/src/shared/types/bookmark.ts
+++ b/src/shared/types/bookmark.ts
@@ -1,6 +1,11 @@
+import type { FitLevel } from './job';
+
 export type Bookmark = {
   id: number;
   postingTitle: string;
   postingUrl: string;
+  companyName: string;
+  deadline: string;
+  fitLevel: FitLevel | '';
   createdAt: string;
 };

--- a/src/shared/ui/JobCard/JobCard.tsx
+++ b/src/shared/ui/JobCard/JobCard.tsx
@@ -26,7 +26,7 @@ function formatCareer(raw: string): string {
 
 type JobCardProps = {
   job: JobPosting;
-  onBookmarkToggle: (id: number) => void;
+  onBookmarkToggle: (job: JobPosting) => void;
 };
 
 export function JobCard({ job, onBookmarkToggle }: JobCardProps) {
@@ -44,7 +44,7 @@ export function JobCard({ job, onBookmarkToggle }: JobCardProps) {
           className="absolute inset-0 rounded-lg"
         />
       )}
-      <header className="flex items-start justify-between gap-3">
+      <header className="flex items-start justify-between gap-3 pb-3">
         <div className="flex flex-col gap-1.5">
           {job.fitLevel && (
             <FitBadge level={job.fitLevel} className="self-start" />
@@ -57,11 +57,13 @@ export function JobCard({ job, onBookmarkToggle }: JobCardProps) {
           <h3 className="line-clamp-1 text-[0.9375rem] font-semibold leading-[1.5] text-gray-900">
             {job.title}
           </h3>
-          <p className="text-[0.875rem] text-gray-500">{job.companyName}</p>
+          {job.companyName && (
+            <p className="text-[0.875rem] text-gray-500">{job.companyName}</p>
+          )}
         </div>
         <button
           type="button"
-          onClick={() => onBookmarkToggle(job.id)}
+          onClick={() => onBookmarkToggle(job)}
           aria-label={job.bookmarked ? '북마크 해제' : '북마크 추가'}
           aria-pressed={job.bookmarked}
           className="transition-ui relative z-10 -mr-1 shrink-0 cursor-pointer rounded-sm text-gray-400 hover:text-primary"
@@ -79,48 +81,58 @@ export function JobCard({ job, onBookmarkToggle }: JobCardProps) {
         </button>
       </header>
 
-      <dl className="mt-3 flex min-w-0 flex-col gap-1.5 pb-3">
-        <div className="flex min-w-0 items-center gap-1">
-          <MapPin
-            size={16}
-            strokeWidth={1.5}
-            className="shrink-0 text-gray-400"
-            aria-hidden="true"
-          />
-          <dt className="sr-only">지역</dt>
-          <dd className="truncate text-[0.8125rem] text-gray-500">
-            {job.location}
-          </dd>
-        </div>
-        {job.reqCareer && (
-          <div className="flex items-center gap-1">
-            <Briefcase
-              size={16}
-              strokeWidth={1.5}
-              className="shrink-0 text-gray-400"
-              aria-hidden="true"
-            />
-            <dt className="sr-only">경력</dt>
-            <dd className="text-[0.8125rem] text-gray-500">
-              {formatCareer(job.reqCareer)}
-            </dd>
-          </div>
-        )}
-      </dl>
+      {(job.location || job.reqCareer) && (
+        <dl className="flex min-w-0 flex-col gap-1.5 pb-3">
+          {job.location && (
+            <div className="flex min-w-0 items-center gap-1">
+              <MapPin
+                size={16}
+                strokeWidth={1.5}
+                className="shrink-0 text-gray-400"
+                aria-hidden="true"
+              />
+              <dt className="sr-only">지역</dt>
+              <dd className="truncate text-[0.8125rem] text-gray-500">
+                {job.location}
+              </dd>
+            </div>
+          )}
+          {job.reqCareer && (
+            <div className="flex items-center gap-1">
+              <Briefcase
+                size={16}
+                strokeWidth={1.5}
+                className="shrink-0 text-gray-400"
+                aria-hidden="true"
+              />
+              <dt className="sr-only">경력</dt>
+              <dd className="text-[0.8125rem] text-gray-500">
+                {formatCareer(job.reqCareer)}
+              </dd>
+            </div>
+          )}
+        </dl>
+      )}
 
-      <footer className="mt-auto border-t border-gray-100 pt-3">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-1 text-gray-400">
-            <Calendar size={14} strokeWidth={1.5} aria-hidden="true" />
-            <span className="text-[0.75rem]">
-              <span className="sr-only">마감일</span>~{job.deadline}
-            </span>
+      {(job.deadline || job.salary) && (
+        <footer className="mt-auto border-t border-gray-100 pt-3">
+          <div className="flex items-center justify-between">
+            {job.deadline && (
+              <div className="flex items-center gap-1 text-gray-400">
+                <Calendar size={14} strokeWidth={1.5} aria-hidden="true" />
+                <span className="text-[0.75rem]">
+                  <span className="sr-only">마감일</span>~{job.deadline}
+                </span>
+              </div>
+            )}
+            {job.salary && (
+              <span className="text-[0.75rem] font-medium text-gray-700">
+                {job.salary}
+              </span>
+            )}
           </div>
-          <span className="text-[0.75rem] font-medium text-gray-700">
-            {job.salary}
-          </span>
-        </div>
-      </footer>
+        </footer>
+      )}
     </article>
   );
 }


### PR DESCRIPTION
## 개요
스크랩 공고 카드에 회사명·마감일·적합도를 표시하고, 북마크 아이콘 클릭 시 낙관적 업데이트로 즉각적인 UI 반응을 제공합니다.

## 주요 변경 사항

### 스크랩 공고 상세 정보 표시
- `bookmarks` 테이블에 `company_name`, `deadline`, `fit_level` 컬럼 추가 (SQL 마이그레이션 필요)
- `Bookmark` 타입에 `companyName`, `deadline`, `fitLevel` 필드 추가
- `ScrapedJobsTab`의 `toJobPosting`에서 실제 저장값 사용

### 북마크 낙관적 업데이트
- `useBookmarkToggle` 훅 추가: `onMutate`에서 즉시 UI 반영, `onError`에서 롤백
- `useBookmarkRemove` 훅 추가: 스크랩 페이지 북마크 해제 처리

### 북마크 POST 에러 수정
- `Prefer: return=representation` 추가 → 201 빈 바디 파싱 실패(500) 해결
- 409(중복) 발생 시 조용히 무시하도록 처리

### JobCard UI 개선
- `header`에 `pb-3` 추가, `dl`의 `mt-3` 제거 → dl 없는 카드(스크랩)의 footer 위아래 여백 균등화

## 마이그레이션

Supabase SQL Editor에서 실행 필요:
```sql
ALTER TABLE bookmarks
  ADD COLUMN company_name text NOT NULL DEFAULT '',
  ADD COLUMN deadline     text NOT NULL DEFAULT '',
  ADD COLUMN fit_level    text NOT NULL DEFAULT '';
```

Closes #98