### PR TITLE
design: 대시보드 채용공고 섹션 스타일 조정 #103

### DIFF
--- a/src/features/dashboard/ui/DashboardView.tsx
+++ b/src/features/dashboard/ui/DashboardView.tsx
@@ -33,7 +33,7 @@ export function DashboardView() {
 
   return (
     <div className="py-10 md:py-16">
-      <div className="mx-auto flex max-w-[1200px] flex-col gap-8 px-4 md:px-5 lg:px-6">
+      <div className="mx-auto flex max-w-[1200px] flex-col gap-[60px] px-4 md:px-5 lg:px-6">
         <section aria-labelledby="result-summary-heading">
           <h2 id="result-summary-heading" className="sr-only">
             검사 결과 요약

--- a/src/features/dashboard/ui/JobListSection.tsx
+++ b/src/features/dashboard/ui/JobListSection.tsx
@@ -34,7 +34,7 @@ export function JobListSection({
     <section aria-labelledby="job-list-heading">
       <h2
         id="job-list-heading"
-        className="mb-5 border-l-[3px] border-primary pl-[10px] text-[1rem] font-semibold leading-[1.5] text-gray-900"
+        className="mb-1 text-[1.375rem] font-semibold leading-[1.5] text-gray-900"
       >
         {userName}님에게 맞는 채용공고
       </h2>

--- a/src/features/dashboard/ui/JobRegionFilter.tsx
+++ b/src/features/dashboard/ui/JobRegionFilter.tsx
@@ -29,7 +29,7 @@ export function JobRegionFilter({
 
   return (
     <>
-      <p className="mb-2 flex items-center gap-1 text-[0.8125rem] text-gray-400">
+      <p className="mb-6 flex items-center gap-1 text-[0.875rem] text-gray-400">
         <Info
           size={14}
           strokeWidth={1.5}
@@ -84,7 +84,7 @@ export function JobRegionFilter({
         <div
           role="group"
           aria-label="적합도 필터"
-          className="mb-4 flex flex-wrap gap-2"
+          className="mb-8 flex flex-wrap gap-2"
         >
           {fitLevelList.map((fitLevel) => (
             <button
@@ -104,7 +104,6 @@ export function JobRegionFilter({
           ))}
         </div>
       )}
-      <hr className="mb-5 mt-4 border-t-2 border-gray-200" />
     </>
   );
 }


### PR DESCRIPTION
## 개요
대시보드 채용공고 섹션의 간격, 타이포그래피, 구분선 등 스타일을 개선합니다.

## 주요 변경 사항
- 섹션 간격 `gap-8` → `gap-[60px]`로 확대
- 채용공고 섹션 제목 border-left 제거, 폰트 크기 22px(text-[1.375rem]), 마진 `mb-1`로 조정
- 필터 안내 문구 폰트 14px, 마진 `mb-6`으로 조정
- 적합도 필터 마진 `mb-8`으로 조정
- 필터와 공고 카드 사이 `hr` 구분선 제거

Closes #103