### PR TITLE
feat: 대시보드 로딩 스켈레톤 적용 #107

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,7 +36,8 @@ export default function Home() {
     staleTime: 1000 * 60 * 5,
   });
 
-  if (userLoading || (user && profileLoading)) return <DashboardView />;
+  if (userLoading) return null;
+  if (user && profileLoading) return <DashboardView />;
 
   if (user && profile) return <DashboardView />;
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,7 +36,7 @@ export default function Home() {
     staleTime: 1000 * 60 * 5,
   });
 
-  if (userLoading || (user && profileLoading)) return null;
+  if (userLoading || (user && profileLoading)) return <DashboardView />;
 
   if (user && profile) return <DashboardView />;
 

--- a/src/features/dashboard/ui/DashboardView.tsx
+++ b/src/features/dashboard/ui/DashboardView.tsx
@@ -11,6 +11,7 @@ import { AIResultCard } from '@/shared/ui/AIResultCard';
 export function DashboardView() {
   const {
     userName,
+    isLoading: isDashboardLoading,
     personalityAxes,
     personalitySummary,
     matchedJobs,
@@ -43,6 +44,7 @@ export function DashboardView() {
             axes={personalityAxes}
             summary={personalitySummary}
             jobs={matchedJobs}
+            isLoading={isDashboardLoading}
           />
         </section>
 
@@ -55,6 +57,7 @@ export function DashboardView() {
             postings={filteredPostings}
             onBookmarkToggle={handleBookmarkToggle}
             isLoading={isJobsLoading}
+            isLoadingUser={isDashboardLoading}
             sigunguList={availableSigungu}
             selectedSigungu={selectedSigungu}
             onSelectSigungu={handleSelectSigungu}

--- a/src/features/dashboard/ui/JobListSection.tsx
+++ b/src/features/dashboard/ui/JobListSection.tsx
@@ -43,17 +43,18 @@ export function JobListSection({
         {isLoadingUser ? '사용자' : userName}님에게 맞는 채용공고
       </h2>
 
-      {isLoading ? (
+      <p className="mb-6 flex items-center gap-1 text-[0.875rem] text-gray-400">
+        <Info
+          size={14}
+          strokeWidth={1.5}
+          aria-hidden="true"
+          className="shrink-0"
+        />
+        주소는 본사 기준이에요. 실제 근무지는 공고에서 확인해주세요.
+      </p>
+
+      {isLoading || isLoadingUser ? (
         <div className="mb-8">
-          <p className="mb-6 flex items-center gap-1 text-[0.875rem] text-gray-400">
-            <Info
-              size={14}
-              strokeWidth={1.5}
-              aria-hidden="true"
-              className="shrink-0"
-            />
-            주소는 본사 기준이에요. 실제 근무지는 공고에서 확인해주세요.
-          </p>
           <div className="mb-2 flex flex-wrap gap-2">
             <Skeleton className="h-8 w-10 rounded-sm" />
             <div className="w-px self-stretch bg-gray-200" />
@@ -85,7 +86,7 @@ export function JobListSection({
         />
       ) : null}
 
-      {isLoading ? (
+      {isLoading || isLoadingUser ? (
         <ul
           aria-busy="true"
           aria-label="채용공고 로딩 중"

--- a/src/features/dashboard/ui/JobListSection.tsx
+++ b/src/features/dashboard/ui/JobListSection.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { Info } from 'lucide-react';
+
 import type { FitLevel, JobPosting } from '@/shared/types/job';
 import { Skeleton } from '@/shared/ui/Skeleton';
 import { JobCard } from './JobCard';
@@ -10,6 +12,7 @@ type JobListSectionProps = {
   postings: JobPosting[];
   onBookmarkToggle: (job: JobPosting) => void;
   isLoading?: boolean;
+  isLoadingUser?: boolean;
   sigunguList?: string[];
   selectedSigungu?: string | null;
   onSelectSigungu?: (sigungu: string | null) => void;
@@ -23,6 +26,7 @@ export function JobListSection({
   postings,
   onBookmarkToggle,
   isLoading = false,
+  isLoadingUser = false,
   sigunguList = [],
   selectedSigungu = null,
   onSelectSigungu,
@@ -36,10 +40,41 @@ export function JobListSection({
         id="job-list-heading"
         className="mb-1 text-[1.375rem] font-semibold leading-[1.5] text-gray-900"
       >
-        {userName}님에게 맞는 채용공고
+        {isLoadingUser ? '사용자' : userName}님에게 맞는 채용공고
       </h2>
 
-      {!isLoading && onSelectSigungu && onSelectFitLevel && (
+      {isLoading ? (
+        <div className="mb-8">
+          <p className="mb-6 flex items-center gap-1 text-[0.875rem] text-gray-400">
+            <Info
+              size={14}
+              strokeWidth={1.5}
+              aria-hidden="true"
+              className="shrink-0"
+            />
+            주소는 본사 기준이에요. 실제 근무지는 공고에서 확인해주세요.
+          </p>
+          <div className="mb-2 flex flex-wrap gap-2">
+            <Skeleton className="h-8 w-10 rounded-sm" />
+            <div className="w-px self-stretch bg-gray-200" />
+            <Skeleton className="h-8 w-16 rounded-sm" />
+            <Skeleton className="h-8 w-14 rounded-sm" />
+            <Skeleton className="h-8 w-20 rounded-sm" />
+            <Skeleton className="h-8 w-14 rounded-sm" />
+            <Skeleton className="h-8 w-16 rounded-sm" />
+            <Skeleton className="h-8 w-12 rounded-sm" />
+            <Skeleton className="h-8 w-16 rounded-sm" />
+            <Skeleton className="h-8 w-14 rounded-sm" />
+            <Skeleton className="h-8 w-16 rounded-sm" />
+            <Skeleton className="h-8 w-12 rounded-sm" />
+          </div>
+          <div className="mb-8 flex flex-wrap gap-2">
+            <Skeleton className="h-8 w-20 rounded-sm" />
+            <Skeleton className="h-8 w-28 rounded-sm" />
+            <Skeleton className="h-8 w-24 rounded-sm" />
+          </div>
+        </div>
+      ) : onSelectSigungu && onSelectFitLevel ? (
         <JobRegionFilter
           sigunguList={sigunguList}
           selectedSigungu={selectedSigungu}
@@ -48,7 +83,7 @@ export function JobListSection({
           selectedFitLevel={selectedFitLevel}
           onSelectFitLevel={onSelectFitLevel}
         />
-      )}
+      ) : null}
 
       {isLoading ? (
         <ul
@@ -56,7 +91,7 @@ export function JobListSection({
           aria-label="채용공고 로딩 중"
           className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3"
         >
-          {Array.from({ length: 4 }).map((_, i) => (
+          {Array.from({ length: 6 }).map((_, i) => (
             <li key={i} className="rounded-lg border border-gray-200 p-5">
               <Skeleton className="mb-3 h-6 w-16 rounded-sm" />
               <Skeleton className="mb-2 h-5 w-3/4 rounded-sm" />

--- a/src/shared/ui/AIResultCard/AIResultCard.tsx
+++ b/src/shared/ui/AIResultCard/AIResultCard.tsx
@@ -1,12 +1,14 @@
 import type { MatchedJob, PersonalityAxis } from '@/shared/types/job';
 import { FitBadge } from '@/shared/ui/FitBadge';
 import { PersonalityRadarChart } from '@/shared/ui/PersonalityRadarChart';
+import { Skeleton } from '@/shared/ui/Skeleton';
 
 type AIResultCardProps = {
   userName: string;
   axes: PersonalityAxis[];
   summary: string;
   jobs: MatchedJob[];
+  isLoading?: boolean;
 };
 
 export function AIResultCard({
@@ -14,7 +16,10 @@ export function AIResultCard({
   axes,
   summary,
   jobs,
+  isLoading = false,
 }: AIResultCardProps) {
+  const displayName = isLoading ? '사용자' : userName;
+
   return (
     <div className="rounded-lg border border-gray-200 bg-white">
       {/* 상단: 직업 성향 + 맞는 직종 TOP 3 */}
@@ -22,40 +27,59 @@ export function AIResultCard({
         {/* 좌: 레이더 차트 */}
         <div className="flex flex-col items-center p-6">
           <h3 className="mb-6 w-full border-l-[3px] border-primary pl-[10px] text-[1rem] font-semibold leading-[1.5] text-gray-900">
-            {userName}님의 직업 성향
+            {displayName}님의 직업 성향
           </h3>
-          <PersonalityRadarChart data={axes} />
+          {isLoading ? (
+            <Skeleton className="h-[240px] w-[240px] rounded-full" />
+          ) : (
+            <PersonalityRadarChart data={axes} />
+          )}
         </div>
 
         {/* 우: 맞는 직종 TOP 3 */}
         <div className="p-6">
           <h3 className="mb-6 border-l-[3px] border-primary pl-[10px] text-[1rem] font-semibold leading-[1.5] text-gray-900">
-            {userName}님에게 맞는 직종 TOP 3
+            {displayName}님에게 맞는 직종 TOP 3
           </h3>
-          <ol className="flex flex-col gap-3" aria-label="매칭 직종 목록">
-            {jobs.map((job, index) => (
-              <li
-                key={job.id}
-                className="flex items-center gap-4 rounded-md border border-gray-200 bg-white px-4 py-3"
-              >
-                <span
-                  className="flex h-6 w-6 shrink-0 items-center justify-center rounded-sm bg-gray-100 text-[0.75rem] font-semibold text-gray-500 tabular-nums"
-                  aria-label={`${index + 1}위`}
+          {isLoading ? (
+            <ol className="flex flex-col gap-3">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <li
+                  key={i}
+                  className="flex items-center gap-4 rounded-md border border-gray-200 px-4 py-3"
                 >
-                  {index + 1}
-                </span>
-                <span className="flex-1 text-[0.9375rem] font-semibold leading-[1.5] text-gray-900">
-                  {job.name}
-                </span>
-                <div className="flex items-center gap-3">
-                  <FitBadge level={job.fitLevel} />
-                  <span className="tabular-nums text-[0.875rem] font-semibold text-primary">
-                    {job.matchRate}%
+                  <Skeleton className="h-6 w-6 shrink-0 rounded-sm" />
+                  <Skeleton className="h-5 flex-1 rounded-sm" />
+                  <Skeleton className="h-5 w-20 rounded-sm" />
+                </li>
+              ))}
+            </ol>
+          ) : (
+            <ol className="flex flex-col gap-3" aria-label="매칭 직종 목록">
+              {jobs.map((job, index) => (
+                <li
+                  key={job.id}
+                  className="flex items-center gap-4 rounded-md border border-gray-200 bg-white px-4 py-3"
+                >
+                  <span
+                    className="flex h-6 w-6 shrink-0 items-center justify-center rounded-sm bg-gray-100 text-[0.75rem] font-semibold text-gray-500 tabular-nums"
+                    aria-label={`${index + 1}위`}
+                  >
+                    {index + 1}
                   </span>
-                </div>
-              </li>
-            ))}
-          </ol>
+                  <span className="flex-1 text-[0.9375rem] font-semibold leading-[1.5] text-gray-900">
+                    {job.name}
+                  </span>
+                  <div className="flex items-center gap-3">
+                    <FitBadge level={job.fitLevel} />
+                    <span className="tabular-nums text-[0.875rem] font-semibold text-primary">
+                      {job.matchRate}%
+                    </span>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          )}
         </div>
       </div>
 
@@ -64,9 +88,16 @@ export function AIResultCard({
         <p className="mb-2 text-[0.875rem] font-semibold text-gray-500">
           AI 성향 요약
         </p>
-        <p className="text-[0.9375rem] leading-[1.6] text-gray-900">
-          &ldquo;{summary}&rdquo;
-        </p>
+        {isLoading ? (
+          <div className="flex flex-col gap-2">
+            <Skeleton className="h-4 w-full rounded-sm" />
+            <Skeleton className="h-4 w-4/5 rounded-sm" />
+          </div>
+        ) : (
+          <p className="text-[0.9375rem] leading-[1.6] text-gray-900">
+            &ldquo;{summary}&rdquo;
+          </p>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## 개요
페이지 새로고침 시 서버 데이터 로딩 중 대시보드의 모든 콘텐츠 영역에 스켈레톤 UI를 표시한다.

## 주요 변경 사항
- `AIResultCard`: `isLoading` prop 추가 — 레이더 차트, 직종 TOP 3 아이템, AI 성향 요약 텍스트를 스켈레톤으로 대체
- `JobListSection`: `isLoadingUser` prop 추가 — 채용공고 타이틀의 닉네임을 로딩 중 `사용자`로 표시
- `DashboardView`: `useDashboard()`의 `isLoading`을 `AIResultCard`와 `JobListSection`에 전달
- 고정 문자열(`AI 성향 요약` 라벨, `주소는 본사 기준이에요` 등)은 로딩 중에도 그대로 표시

Closes #107