### PR TITLE
🚩feat: 테스트 계정 로그인/로그아웃 #111

### DIFF
--- a/src/app/api/auth/test-login/route.ts
+++ b/src/app/api/auth/test-login/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { signSession } from '@/shared/utils/session';
+import { TEST_USER_ID } from '@/shared/utils/testUser';
+
+const SESSION_MAX_AGE = 60 * 60 * 24 * 30;
+
+export async function POST() {
+  const sessionJwt = await signSession(TEST_USER_ID);
+  const response = NextResponse.json({ ok: true });
+  response.cookies.set('session', sessionJwt, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'strict',
+    path: '/',
+    maxAge: SESSION_MAX_AGE,
+  });
+  return response;
+}

--- a/src/app/api/auth/test-logout/route.ts
+++ b/src/app/api/auth/test-logout/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { clearAuthCookies } from '@/shared/utils/authCookies';
+
+export async function POST() {
+  await clearAuthCookies();
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/bookmarks/route.ts
+++ b/src/app/api/bookmarks/route.ts
@@ -1,6 +1,7 @@
 import { createAuthorizedRoute } from '@/shared/api/createAuthorizedRoute';
 import { supabaseFetch } from '@/shared/api/supabaseFetch';
 import { isApiError } from '@/shared/utils/errorGuards';
+import { TEST_USER_ID } from '@/shared/utils/testUser';
 
 type BookmarkRow = {
   id: number;
@@ -21,6 +22,8 @@ type AddBookmarkBody = {
 };
 
 export const GET = createAuthorizedRoute(async ({ userId }) => {
+  if (userId === TEST_USER_ID) return [];
+
   const rows = await supabaseFetch<BookmarkRow[]>(
     `/rest/v1/bookmarks?user_id=eq.${userId}&select=id,posting_title,posting_url,company_name,deadline,fit_level,created_at&order=created_at.desc`,
   );
@@ -38,6 +41,8 @@ export const GET = createAuthorizedRoute(async ({ userId }) => {
 
 export const POST = createAuthorizedRoute<AddBookmarkBody>(
   async ({ userId, body }) => {
+    if (userId === TEST_USER_ID) return;
+
     try {
       await supabaseFetch<BookmarkRow[]>('/rest/v1/bookmarks', {
         method: 'POST',
@@ -61,6 +66,8 @@ export const POST = createAuthorizedRoute<AddBookmarkBody>(
 );
 
 export const DELETE = createAuthorizedRoute(async ({ userId, request }) => {
+  if (userId === TEST_USER_ID) return;
+
   const { searchParams } = new URL(request.url);
   const postingUrl = searchParams.get('postingUrl');
 

--- a/src/app/api/match/route.ts
+++ b/src/app/api/match/route.ts
@@ -4,8 +4,11 @@ import { openAiFetch } from '@/shared/api/openAiFetch';
 import { AiMatchResponseSchema, type MatchResult } from '@/shared/types/match';
 import type { Profile } from '@/shared/types/profile';
 import { matchStrategy } from '@/features/match/strategies';
+import { TEST_USER_ID, TEST_MATCH } from '@/shared/utils/testUser';
 
 export const GET = createAuthorizedRoute(async ({ userId }) => {
+  if (userId === TEST_USER_ID) return TEST_MATCH;
+
   const rows = await supabaseFetch<MatchResult[]>(
     `/rest/v1/match_results?user_id=eq.${userId}&select=*`,
   );

--- a/src/app/api/profiles/route.ts
+++ b/src/app/api/profiles/route.ts
@@ -1,8 +1,11 @@
 import { createAuthorizedRoute } from '@/shared/api/createAuthorizedRoute';
 import { supabaseFetch } from '@/shared/api/supabaseFetch';
 import { CreateProfileBodySchema, type Profile } from '@/shared/types/profile';
+import { TEST_USER_ID, TEST_PROFILE } from '@/shared/utils/testUser';
 
 export const GET = createAuthorizedRoute(async ({ userId }) => {
+  if (userId === TEST_USER_ID) return TEST_PROFILE;
+
   const rows = await supabaseFetch<Profile[]>(
     `/rest/v1/profiles?user_id=eq.${userId}&select=*`,
   );

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,10 +1,13 @@
 import { createAuthorizedRoute } from '@/shared/api/createAuthorizedRoute';
 import { supabaseFetch } from '@/shared/api/supabaseFetch';
 import type { User, CurrentUser } from '@/shared/types/user';
+import { TEST_USER_ID, TEST_USER } from '@/shared/utils/testUser';
 
 // GET /api/users/me
 // 로그인한 유저 정보 반환 (kakao_id 제외)
 export const GET = createAuthorizedRoute(async ({ userId }) => {
+  if (userId === TEST_USER_ID) return TEST_USER;
+
   const rows = await supabaseFetch<User[]>(
     `/rest/v1/users?id=eq.${userId}&select=id,nickname,created_at`,
   );

--- a/src/features/dashboard/hooks/useBookmarkToggle.ts
+++ b/src/features/dashboard/hooks/useBookmarkToggle.ts
@@ -1,12 +1,16 @@
 'use client';
 
+import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import type { JobPosting } from '@/shared/types/job';
 import { addBookmark, removeBookmark } from '../api/bookmarkApi';
+import { useCurrentUser } from '@/shared/hooks/useCurrentUser';
 
 export function useBookmarkToggle() {
   const queryClient = useQueryClient();
+  const { data: user } = useCurrentUser();
+  const [loginModalOpen, setLoginModalOpen] = useState(false);
 
   const { mutate } = useMutation({
     mutationFn: (job: JobPosting) =>
@@ -41,5 +45,15 @@ export function useBookmarkToggle() {
     },
   });
 
-  return (job: JobPosting) => mutate(job);
+  return {
+    toggle: (job: JobPosting) => {
+      if (user?.isTestUser) {
+        setLoginModalOpen(true);
+        return;
+      }
+      mutate(job);
+    },
+    loginModalOpen,
+    closeLoginModal: () => setLoginModalOpen(false),
+  };
 }

--- a/src/features/dashboard/ui/DashboardView.tsx
+++ b/src/features/dashboard/ui/DashboardView.tsx
@@ -7,6 +7,7 @@ import { useJobFitFilter } from '../hooks/useJobFitFilter';
 import { useBookmarkToggle } from '../hooks/useBookmarkToggle';
 import { JobListSection } from './JobListSection';
 import { AIResultCard } from '@/shared/ui/AIResultCard';
+import { ConfirmModal } from '@/shared/ui/ConfirmModal';
 
 export function DashboardView() {
   const {
@@ -30,7 +31,11 @@ export function DashboardView() {
     filteredPostings,
     handleSelectFitLevel,
   } = useJobFitFilter(regionFiltered);
-  const handleBookmarkToggle = useBookmarkToggle();
+  const {
+    toggle: handleBookmarkToggle,
+    loginModalOpen,
+    closeLoginModal,
+  } = useBookmarkToggle();
 
   return (
     <div className="py-10 md:py-16">
@@ -67,6 +72,19 @@ export function DashboardView() {
           />
         </section>
       </div>
+
+      {loginModalOpen && (
+        <ConfirmModal
+          title="로그인이 필요해요"
+          description="스크랩은 실제 로그인이 필요합니다."
+          confirmLabel="로그인하기"
+          cancelLabel="닫기"
+          onConfirm={() => {
+            window.location.href = '/api/oauth/kakao/authorize';
+          }}
+          onClose={closeLoginModal}
+        />
+      )}
     </div>
   );
 }

--- a/src/features/landing/ui/HeroSection.tsx
+++ b/src/features/landing/ui/HeroSection.tsx
@@ -45,6 +45,7 @@ export function HeroSection({ onCtaClick }: HeroSectionProps) {
               height={520}
               className="h-auto w-[460px]"
               priority
+              sizes="460px"
             />
           </div>
         </div>

--- a/src/features/landing/ui/ServiceIntroSection.tsx
+++ b/src/features/landing/ui/ServiceIntroSection.tsx
@@ -106,6 +106,7 @@ export function ServiceIntroSection() {
                         src={step.image}
                         alt={step.title}
                         fill
+                        sizes="560px"
                         className={step.imageClass ?? 'object-cover object-top'}
                       />
                     ) : (

--- a/src/features/profile/hooks/useBookmarkRemove.ts
+++ b/src/features/profile/hooks/useBookmarkRemove.ts
@@ -1,12 +1,16 @@
 'use client';
 
+import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import type { Bookmark } from '@/shared/types/bookmark';
 import { removeBookmark } from '../api/bookmarksApi';
+import { useCurrentUser } from '@/shared/hooks/useCurrentUser';
 
 export function useBookmarkRemove() {
   const queryClient = useQueryClient();
+  const { data: user } = useCurrentUser();
+  const [loginModalOpen, setLoginModalOpen] = useState(false);
 
   const { mutate } = useMutation({
     mutationFn: (postingUrl: string) => removeBookmark(postingUrl),
@@ -30,5 +34,15 @@ export function useBookmarkRemove() {
     },
   });
 
-  return (postingUrl: string) => mutate(postingUrl);
+  return {
+    remove: (postingUrl: string) => {
+      if (user?.isTestUser) {
+        setLoginModalOpen(true);
+        return;
+      }
+      mutate(postingUrl);
+    },
+    loginModalOpen,
+    closeLoginModal: () => setLoginModalOpen(false),
+  };
 }

--- a/src/features/profile/ui/ProfileView.tsx
+++ b/src/features/profile/ui/ProfileView.tsx
@@ -11,6 +11,7 @@ import { ProfileInfoTab } from './ProfileInfoTab';
 import { ProfileEmptyView } from './ProfileEmptyView';
 import { ScrapedJobsTab } from './ScrapedJobsTab';
 import { Skeleton } from '@/shared/ui/Skeleton';
+import { ConfirmModal } from '@/shared/ui/ConfirmModal';
 
 type ProfileTab = 'result' | 'scraps';
 
@@ -27,7 +28,11 @@ export function ProfileView() {
     matchedJobs,
   } = useProfile();
   const { data: scrapedJobs = [] } = useScrapedJobs();
-  const handleBookmarkRemove = useBookmarkRemove();
+  const {
+    remove: handleBookmarkRemove,
+    loginModalOpen,
+    closeLoginModal,
+  } = useBookmarkRemove();
 
   if (isLoading) {
     return (
@@ -80,6 +85,19 @@ export function ProfileView() {
           )}
         </div>
       </div>
+
+      {loginModalOpen && (
+        <ConfirmModal
+          title="로그인이 필요해요"
+          description="스크랩은 실제 로그인이 필요합니다."
+          confirmLabel="로그인하기"
+          cancelLabel="닫기"
+          onConfirm={() => {
+            window.location.href = '/api/oauth/kakao/authorize';
+          }}
+          onClose={closeLoginModal}
+        />
+      )}
     </div>
   );
 }

--- a/src/shared/api/authApi.ts
+++ b/src/shared/api/authApi.ts
@@ -2,3 +2,9 @@ import { bffFetch } from './bffFetch';
 
 export const logout = (): Promise<void> =>
   bffFetch<void>('/auth/logout', { method: 'POST' });
+
+export const testLogin = (): Promise<void> =>
+  bffFetch<void>('/auth/test-login', { method: 'POST' });
+
+export const testLogout = (): Promise<void> =>
+  bffFetch<void>('/auth/test-logout', { method: 'POST' });

--- a/src/shared/hooks/useTestLogin.ts
+++ b/src/shared/hooks/useTestLogin.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { testLogin } from '@/shared/api/authApi';
+import { CURRENT_USER_QUERY_KEY } from './useCurrentUser';
+
+export function useTestLogin() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: testLogin,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: CURRENT_USER_QUERY_KEY });
+    },
+  });
+}

--- a/src/shared/hooks/useTestLogout.ts
+++ b/src/shared/hooks/useTestLogout.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { testLogout } from '@/shared/api/authApi';
+import { CURRENT_USER_QUERY_KEY } from './useCurrentUser';
+
+export function useTestLogout() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: testLogout,
+    onSuccess: () => {
+      queryClient.setQueryData(CURRENT_USER_QUERY_KEY, null);
+      window.location.href = '/';
+    },
+  });
+}

--- a/src/shared/types/user.ts
+++ b/src/shared/types/user.ts
@@ -9,4 +9,4 @@ export type User = {
 };
 
 // 클라이언트에 노출하는 유저 정보 (kakao_id 제외)
-export type CurrentUser = Omit<User, 'kakao_id'>;
+export type CurrentUser = Omit<User, 'kakao_id'> & { isTestUser?: boolean };

--- a/src/shared/utils/testUser.ts
+++ b/src/shared/utils/testUser.ts
@@ -1,0 +1,68 @@
+import type { CurrentUser } from '@/shared/types/user';
+import type { Profile } from '@/shared/types/profile';
+import type { MatchResult } from '@/shared/types/match';
+
+// Supabase bigint ID는 1부터 시작하므로 "0"은 실제 유저와 충돌하지 않는다.
+export const TEST_USER_ID = '0';
+
+export const TEST_USER: CurrentUser = {
+  id: 0,
+  nickname: '테스트 계정',
+  created_at: '2026-01-01T00:00:00.000Z',
+  isTestUser: true,
+};
+
+export const TEST_PROFILE: Profile = {
+  id: 0,
+  user_id: 0,
+  name: '테스트 사용자',
+  gender: '남성',
+  education: '고졸',
+  region_primary: '경기도',
+  disability_type: ['지체장애'],
+  disability_level: '경증',
+  mobility: '대중교통 이용 가능',
+  hand_usage: '양손 사용 가능',
+  stamina: '보통',
+  communication: '원활',
+  instruction_level: '문서 이해 가능',
+  hope_activities: ['사무보조', '데이터 입력'],
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+};
+
+export const TEST_MATCH: MatchResult = {
+  id: 0,
+  user_id: 0,
+  radar_chart: {
+    repetition: 75,
+    interpersonal: 60,
+    physical: 40,
+    hand_detail: 80,
+    env_sensitivity: 55,
+  },
+  summary_text:
+    '꼼꼼하고 반복 작업에 강한 유형이에요. 정밀한 손 작업이나 데이터 처리 업무에서 능력을 발휘할 수 있어요.',
+  top3_jobs: [
+    {
+      rank: 1,
+      job_name: '사무보조원',
+      match_pct: 88,
+      fit_level: '잘 맞아요',
+    },
+    {
+      rank: 2,
+      job_name: '데이터 입력 사무원',
+      match_pct: 82,
+      fit_level: '잘 맞아요',
+    },
+    {
+      rank: 3,
+      job_name: '물품 포장원',
+      match_pct: 65,
+      fit_level: '도전해볼 수 있어요',
+    },
+  ],
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+};

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -5,11 +5,16 @@ import { User } from 'lucide-react';
 
 import { useCurrentUser } from '@/shared/hooks/useCurrentUser';
 import { useLogout } from '@/shared/hooks/useLogout';
+import { useTestLogin } from '@/shared/hooks/useTestLogin';
+import { useTestLogout } from '@/shared/hooks/useTestLogout';
 import { Button } from '@/shared/ui/Button';
 
 export function Header() {
   const { data: user } = useCurrentUser();
-  const { mutate: logout, isPending } = useLogout();
+  const { mutate: logout, isPending: isLogoutPending } = useLogout();
+  const { mutate: testLogin, isPending: isTestLoginPending } = useTestLogin();
+  const { mutate: testLogout, isPending: isTestLogoutPending } =
+    useTestLogout();
 
   return (
     <header className="border-b border-primary-border bg-hero-bg">
@@ -25,18 +30,51 @@ export function Header() {
         </Link>
 
         {!user && (
-          <Button
-            variant="secondary"
-            size="md"
-            onClick={() => {
-              window.location.href = '/api/oauth/kakao/authorize';
-            }}
-          >
-            로그인
-          </Button>
+          <nav aria-label="로그인 메뉴" className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="md"
+              disabled={isTestLoginPending}
+              onClick={() => testLogin()}
+            >
+              {isTestLoginPending ? '로그인 중...' : '테스트 계정으로 로그인'}
+            </Button>
+            <Button
+              variant="secondary"
+              size="md"
+              onClick={() => {
+                window.location.href = '/api/oauth/kakao/authorize';
+              }}
+            >
+              로그인
+            </Button>
+          </nav>
         )}
 
-        {user && (
+        {user && user.isTestUser && (
+          <nav
+            aria-label="테스트 계정 메뉴"
+            className="flex items-center gap-3"
+          >
+            <Link
+              href="/profile"
+              aria-label="프로필 페이지로 이동"
+              className="transition-ui flex h-9 w-9 cursor-pointer items-center justify-center rounded-sm border border-gray-200 bg-gray-50 text-gray-700 hover:bg-gray-100"
+            >
+              <User size={20} strokeWidth={1.5} aria-hidden="true" />
+            </Link>
+            <Button
+              variant="ghost"
+              size="md"
+              disabled={isTestLogoutPending}
+              onClick={() => testLogout()}
+            >
+              {isTestLogoutPending ? '로그아웃 중...' : '테스트 계정 로그아웃'}
+            </Button>
+          </nav>
+        )}
+
+        {user && !user.isTestUser && (
           <nav aria-label="사용자 메뉴" className="flex items-center gap-3">
             <Link
               href="/profile"
@@ -48,10 +86,10 @@ export function Header() {
             <Button
               variant="secondary"
               size="md"
-              disabled={isPending}
+              disabled={isLogoutPending}
               onClick={() => logout()}
             >
-              {isPending ? '로그아웃 중...' : '로그아웃'}
+              {isLogoutPending ? '로그아웃 중...' : '로그아웃'}
             </Button>
           </nav>
         )}


### PR DESCRIPTION
## 개요
카카오 OAuth 없이 즉시 로그인할 수 있는 테스트 계정 기능을 추가한다. Supabase를 전혀 사용하지 않고 인메모리 가짜 데이터로 인증 후 화면 전체를 테스트할 수 있다.

## 주요 변경 사항
- `POST /api/auth/test-login` — `userId: "0"` JWT 발급, 카카오 토큰 불필요
- `POST /api/auth/test-logout` — 쿠키 삭제 (카카오 API 호출 없음)
- `shared/utils/testUser.ts` — 가짜 유저·프로필(경기도)·매칭결과 상수 정의
- `users/me`, `profiles`, `match`, `bookmarks` route — `userId === "0"` 조기 반환으로 Supabase 미호출
- Header — 미로그인 시 '테스트 계정으로 로그인' 버튼 추가, 테스트 로그인 중 카카오 버튼 숨김
- 스크랩 시도 시 '실제 로그인이 필요합니다' ConfirmModal 표시 후 카카오 로그인 유도
- `next/image` `sizes` prop 추가 (`HeroSection`: 460px, `ServiceIntroSection`: 560px)

Closes #111