### PR TITLE
fix: 프로필 지역 수정 후 이전 지역 채용공고 순간 노출 버그 수정 #113

### DIFF
--- a/src/features/survey/hooks/useSurveyForm.ts
+++ b/src/features/survey/hooks/useSurveyForm.ts
@@ -186,7 +186,7 @@ export function useSurveyForm(mode: 'create' | 'edit' = 'create') {
     });
 
     queryClient.invalidateQueries({ queryKey: ['profile'] });
-    queryClient.invalidateQueries({ queryKey: ['job-postings'] });
+    queryClient.removeQueries({ queryKey: ['job-postings'] });
     localStorage.removeItem('matchzoom-job-sigungu-filter');
     localStorage.removeItem('matchzoom-job-fitlevel-filter');
     setIsMatching(true);


### PR DESCRIPTION
## 개요
프로필에서 지역을 변경한 뒤 대시보드로 돌아올 때, 느린 네트워크 환경에서 이전 지역의 채용공고가 순간적으로 노출되는 버그를 수정한다.

## 주요 변경 사항
- `useSurveyForm.ts`: `job-postings` 쿼리 무효화 방식을 `invalidateQueries` → `removeQueries`로 변경
- `invalidateQueries`는 캐시를 stale 표시만 하므로 TanStack Query가 stale-while-revalidate 방식으로 이전 데이터를 먼저 렌더링함
- `removeQueries`로 캐시를 완전히 제거해 로딩 스켈레톤 → 새 지역 공고 순서로 표시되도록 수정

Closes #113