### PR TITLE
fix: 테스트 계정 채용공고 적합도 태그·지역 필터 누락 #115

### DIFF
--- a/src/app/api/job-postings/route.ts
+++ b/src/app/api/job-postings/route.ts
@@ -3,6 +3,7 @@ import { XMLParser } from 'fast-xml-parser';
 import { createAuthorizedRoute } from '@/shared/api/createAuthorizedRoute';
 import { supabaseFetch } from '@/shared/api/supabaseFetch';
 import type { FitLevel } from '@/shared/types/job';
+import { TEST_USER_ID, TEST_PROFILE } from '@/shared/utils/testUser';
 
 type RawItem = {
   busplaName?: string;
@@ -80,13 +81,20 @@ export const GET = createAuthorizedRoute(async ({ userId }) => {
     throw new Error('JOB_API_BASE_URL 또는 JOB_API_KEY 환경변수가 없습니다.');
   }
 
+  const testProfile: ProfileRow | undefined =
+    userId === TEST_USER_ID ? TEST_PROFILE : undefined;
+
   const [profileRows, bookmarkRows, jobXml] = await Promise.all([
-    supabaseFetch<ProfileRow[]>(
-      `/rest/v1/profiles?user_id=eq.${userId}&select=mobility,hand_usage,stamina,communication,region_primary`,
-    ),
-    supabaseFetch<{ posting_url: string }[]>(
-      `/rest/v1/bookmarks?user_id=eq.${userId}&select=posting_url`,
-    ),
+    testProfile
+      ? Promise.resolve([testProfile])
+      : supabaseFetch<ProfileRow[]>(
+          `/rest/v1/profiles?user_id=eq.${userId}&select=mobility,hand_usage,stamina,communication,region_primary`,
+        ),
+    userId === TEST_USER_ID
+      ? Promise.resolve([])
+      : supabaseFetch<{ posting_url: string }[]>(
+          `/rest/v1/bookmarks?user_id=eq.${userId}&select=posting_url`,
+        ),
     fetch(
       `${baseUrl}?serviceKey=${encodeURIComponent(serviceKey)}&numOfRows=100&pageNo=1`,
       { next: { revalidate: 300 } },

--- a/src/features/dashboard/ui/JobListSection.tsx
+++ b/src/features/dashboard/ui/JobListSection.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { Info } from 'lucide-react';
-
 import type { FitLevel, JobPosting } from '@/shared/types/job';
 import { Skeleton } from '@/shared/ui/Skeleton';
 import { JobCard } from './JobCard';
@@ -42,16 +40,6 @@ export function JobListSection({
       >
         {isLoadingUser ? '사용자' : userName}님에게 맞는 채용공고
       </h2>
-
-      <p className="mb-6 flex items-center gap-1 text-[0.875rem] text-gray-400">
-        <Info
-          size={14}
-          strokeWidth={1.5}
-          aria-hidden="true"
-          className="shrink-0"
-        />
-        주소는 본사 기준이에요. 실제 근무지는 공고에서 확인해주세요.
-      </p>
 
       {isLoading || isLoadingUser ? (
         <div className="mb-8">


### PR DESCRIPTION
## 개요
테스트 계정으로 대시보드 접속 시 채용공고 '잘 맞아요' 태그와 지역 필터가 표시되지 않는 버그 수정

## 주요 변경 사항
- `/api/job-postings`: userId가 TEST_USER_ID("0")일 때 Supabase 프로필 조회 대신 TEST_PROFILE 직접 주입 → 적합도 점수 계산 및 경기도 지역 필터링 정상 동작
- `JobListSection.tsx`: 중복 출력되던 "주소는 본사 기준이에요..." 문구 제거 (JobRegionFilter.tsx에도 동일 문구 존재)

Closes #115