### PR TITLE
feat: 레이더 차트 호버 툴팁 추가 #119

### DIFF
--- a/src/shared/ui/PersonalityRadarChart/PersonalityRadarChart.tsx
+++ b/src/shared/ui/PersonalityRadarChart/PersonalityRadarChart.tsx
@@ -6,9 +6,29 @@ import {
   PolarGrid,
   PolarAngleAxis,
   ResponsiveContainer,
+  Tooltip,
 } from 'recharts';
 
 import type { PersonalityAxis } from '@/shared/types/job';
+
+type TooltipProps = {
+  active?: boolean;
+  payload?: Array<{ payload: PersonalityAxis }>;
+};
+
+function ChartTooltip({ active, payload }: TooltipProps) {
+  if (!active || !payload?.length) return null;
+  const { subject, value, fullMark } = payload[0].payload;
+  return (
+    <div className="rounded-md border border-gray-200 bg-white px-3 py-2 shadow-sm">
+      <p className="text-[0.8125rem] font-semibold text-gray-700">{subject}</p>
+      <p className="text-[0.8125rem] font-semibold text-primary">
+        {value}
+        <span className="font-normal text-gray-400"> / {fullMark}</span>
+      </p>
+    </div>
+  );
+}
 
 type PersonalityRadarChartProps = {
   data: PersonalityAxis[];
@@ -34,6 +54,7 @@ export function PersonalityRadarChart({ data }: PersonalityRadarChartProps) {
               fontWeight: 400,
             }}
           />
+          <Tooltip content={<ChartTooltip />} cursor={false} />
           <Radar
             name="특성"
             dataKey="value"
@@ -41,6 +62,13 @@ export function PersonalityRadarChart({ data }: PersonalityRadarChartProps) {
             fill="var(--primary)"
             fillOpacity={0.3}
             strokeWidth={1.5}
+            dot={{ r: 3, fill: 'var(--primary)', strokeWidth: 0 }}
+            activeDot={{
+              r: 5,
+              fill: 'var(--primary)',
+              strokeWidth: 2,
+              stroke: 'white',
+            }}
           />
         </RadarChart>
       </ResponsiveContainer>

--- a/src/shared/ui/PersonalityRadarChart/PersonalityRadarChart.tsx
+++ b/src/shared/ui/PersonalityRadarChart/PersonalityRadarChart.tsx
@@ -11,16 +11,22 @@ import {
 
 import type { PersonalityAxis } from '@/shared/types/job';
 
-type TooltipProps = {
+type ChartTooltipProps = {
   active?: boolean;
   payload?: Array<{ payload: PersonalityAxis }>;
 };
 
-function ChartTooltip({ active, payload }: TooltipProps) {
+function ChartTooltip({ active, payload }: ChartTooltipProps) {
   if (!active || !payload?.length) return null;
   const { subject, value, fullMark } = payload[0].payload;
   return (
-    <div className="rounded-md border border-gray-200 bg-white px-3 py-2 shadow-sm">
+    <div
+      className="rounded-md px-3 py-2 shadow-sm"
+      style={{
+        background: 'var(--white, white)',
+        border: '1px solid var(--gray-200)',
+      }}
+    >
       <p className="text-[0.8125rem] font-semibold text-gray-700">{subject}</p>
       <p className="text-[0.8125rem] font-semibold text-primary">
         {value}
@@ -67,7 +73,7 @@ export function PersonalityRadarChart({ data }: PersonalityRadarChartProps) {
               r: 5,
               fill: 'var(--primary)',
               strokeWidth: 2,
-              stroke: 'white',
+              stroke: 'var(--white, white)',
             }}
           />
         </RadarChart>


### PR DESCRIPTION
## 개요
직업 성향 레이더 차트에 호버 시 각 축의 점수를 표시하는 툴팁을 추가한다.

## 주요 변경 사항
- `PersonalityRadarChart`에 Recharts `Tooltip` 추가 — 커스텀 렌더러로 축 이름과 점수(`82 / 100`) 표시
- 폴리곤 꼭짓점에 상시 dot(r=3) 표시로 호버 타겟 명확화
- 호버 시 흰 테두리 activeDot(r=5)으로 강조
- `cursor={false}`로 Recharts 기본 커서 오버레이 제거

Closes #119