### PR TITLE
test: 채용공고 BFF Route Handler / Feature API 테스트 추가 #126

### DIFF
--- a/src/features/dashboard/__tests__/jobPostingsApi.test.ts
+++ b/src/features/dashboard/__tests__/jobPostingsApi.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/shared/api/bffFetch', () => ({ bffFetch: vi.fn() }));
+
+import { bffFetch } from '@/shared/api/bffFetch';
+import { getJobPostings } from '../api/jobPostingsApi';
+
+const mockBffFetch = vi.mocked(bffFetch);
+
+const mockPosting = {
+  id: 1,
+  companyName: '테스트 회사',
+  title: '사무보조원',
+  location: '경기도 수원시',
+  salary: '2,000,000원 (월급)',
+  deadline: '2026-05-31',
+  empType: '정규직',
+  reqCareer: '신입',
+  reqEduc: '고졸',
+  envConditions: [],
+  fitLevel: '잘 맞아요',
+  detailUrl: 'https://www.work24.go.kr/...',
+  bookmarked: false,
+};
+
+describe('getJobPostings', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('GET /job-postings를 호출하고 목록을 반환한다', async () => {
+    mockBffFetch.mockResolvedValue([mockPosting]);
+
+    const result = await getJobPostings();
+
+    expect(mockBffFetch).toHaveBeenCalledWith('/job-postings', {
+      method: 'GET',
+      signal: undefined,
+    });
+    expect(result).toEqual([mockPosting]);
+  });
+
+  it('AbortSignal을 전달한다', async () => {
+    mockBffFetch.mockResolvedValue([]);
+    const controller = new AbortController();
+
+    await getJobPostings(controller.signal);
+
+    expect(mockBffFetch).toHaveBeenCalledWith('/job-postings', {
+      method: 'GET',
+      signal: controller.signal,
+    });
+  });
+
+  it('에러를 그대로 전파한다', async () => {
+    mockBffFetch.mockRejectedValue(new Error('네트워크 오류'));
+
+    await expect(getJobPostings()).rejects.toThrow('네트워크 오류');
+  });
+});

--- a/src/features/dashboard/__tests__/jobPostingsRoute.test.ts
+++ b/src/features/dashboard/__tests__/jobPostingsRoute.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from '@/app/api/job-postings/route';
+
+vi.mock('next/headers', () => ({ cookies: vi.fn() }));
+vi.mock('@/shared/api/supabaseFetch', () => ({ supabaseFetch: vi.fn() }));
+vi.mock('@/shared/utils/authCookies', () => ({ getAuthCookie: vi.fn() }));
+vi.mock('@/shared/utils/session', () => ({ verifySession: vi.fn() }));
+
+import { supabaseFetch } from '@/shared/api/supabaseFetch';
+import { getAuthCookie } from '@/shared/utils/authCookies';
+import { verifySession } from '@/shared/utils/session';
+
+const mockSupabaseFetch = vi.mocked(supabaseFetch);
+const mockGetAuthCookie = vi.mocked(getAuthCookie);
+const mockVerifySession = vi.mocked(verifySession);
+
+const mockAuth = (userId: string | null) => {
+  if (userId) {
+    mockGetAuthCookie.mockResolvedValue('token');
+    mockVerifySession.mockResolvedValue({ userId });
+  } else {
+    mockGetAuthCookie.mockResolvedValue(undefined);
+    mockVerifySession.mockResolvedValue(null);
+  }
+};
+
+// fast-xml-parser가 숫자 필드를 number로 파싱하므로 XML은 하드코딩 문자열로 고정
+const JOB_XML_ONE_ITEM = `<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <body>
+    <items>
+      <item>
+        <rno>1</rno>
+        <busplaName>테스트 회사</busplaName>
+        <jobNm>사무보조원</jobNm>
+        <compAddr>경기도 수원시 팔달구</compAddr>
+        <empType>정규직</empType>
+        <salary>월 2,000,000원</salary>
+        <salaryType>월급</salaryType>
+        <termDate>20260101~20260531</termDate>
+        <reqCareer>신입</reqCareer>
+        <reqEduc>고졸</reqEduc>
+        <regagnName>한국장애인고용공단 경기지사</regagnName>
+      </item>
+    </items>
+  </body>
+</response>`;
+
+const JOB_XML_EMPTY = `<?xml version="1.0" encoding="UTF-8"?>
+<response><body><items></items></body></response>`;
+
+const mockProfileRow = {
+  mobility: '도보 이동 가능',
+  hand_usage: '세밀한 작업 가능',
+  stamina: '4시간 이상 활동 가능',
+  communication: '일상 대화 가능',
+  region_primary: '경기도 수원시',
+};
+
+const makeRequest = () =>
+  new Request('http://localhost/api/job-postings', { method: 'GET' });
+
+const mockFetchWith = (xml: string) =>
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({ text: () => Promise.resolve(xml) }),
+  );
+
+describe('GET /api/job-postings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.JOB_API_BASE_URL = 'https://api.example.com/jobs';
+    process.env.JOB_API_KEY = 'test-key';
+    mockFetchWith(JOB_XML_ONE_ITEM);
+  });
+
+  it('공고 목록을 반환한다', async () => {
+    mockAuth('1');
+    mockSupabaseFetch
+      .mockResolvedValueOnce([mockProfileRow])
+      .mockResolvedValueOnce([]);
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(Array.isArray(data)).toBe(true);
+    expect(data[0]).toMatchObject({
+      companyName: '테스트 회사',
+      title: '사무보조원',
+    });
+  });
+
+  it('프로필 없으면 필터링 없이 목록을 반환한다', async () => {
+    mockAuth('1');
+    mockSupabaseFetch.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(Array.isArray(data)).toBe(true);
+  });
+
+  it('북마크된 공고는 bookmarked: true로 반환한다', async () => {
+    const detailUrl = `https://www.work24.go.kr/wk/a/b/1700/themeEmpInfoSrchList.do?thmaHrplCd=F00036&resultCnt=10&searchMode=Y&currentPageNo=1&pageIndex=1&sortField=DATE&sortOrderBy=DESC&srcKeyword=${encodeURIComponent('테스트 회사')}`;
+
+    mockAuth('1');
+    mockSupabaseFetch
+      .mockResolvedValueOnce([mockProfileRow])
+      .mockResolvedValueOnce([{ posting_url: detailUrl }]);
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    const bookmarked = data.find((p: { bookmarked: boolean }) => p.bookmarked);
+    expect(bookmarked).toBeDefined();
+  });
+
+  it('공고가 없으면 빈 배열을 반환한다', async () => {
+    mockFetchWith(JOB_XML_EMPTY);
+    mockAuth('1');
+    mockSupabaseFetch
+      .mockResolvedValueOnce([mockProfileRow])
+      .mockResolvedValueOnce([]);
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data).toEqual([]);
+  });
+
+  it('쿠키 없으면 401을 반환한다', async () => {
+    mockAuth(null);
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it('Supabase 오류 시 500을 반환한다', async () => {
+    mockAuth('1');
+    mockSupabaseFetch.mockRejectedValue(new Error('DB 오류'));
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(500);
+  });
+
+  it('환경변수 없으면 500을 반환한다', async () => {
+    mockAuth('1');
+    delete process.env.JOB_API_BASE_URL;
+    delete process.env.JOB_API_KEY;
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(500);
+  });
+
+  it('외부 API 오류 시 500을 반환한다', async () => {
+    mockAuth('1');
+    mockSupabaseFetch
+      .mockResolvedValueOnce([mockProfileRow])
+      .mockResolvedValueOnce([]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new Error('외부 API 오류')),
+    );
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/features/dashboard/__tests__/jobPostingsRoute.test.ts
+++ b/src/features/dashboard/__tests__/jobPostingsRoute.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { GET } from '@/app/api/job-postings/route';
 
 vi.mock('next/headers', () => ({ cookies: vi.fn() }));
@@ -35,7 +35,7 @@ const JOB_XML_ONE_ITEM = `<?xml version="1.0" encoding="UTF-8"?>
         <jobNm>사무보조원</jobNm>
         <compAddr>경기도 수원시 팔달구</compAddr>
         <empType>정규직</empType>
-        <salary>월 2,000,000원</salary>
+        <salary>2,000,000</salary>
         <salaryType>월급</salaryType>
         <termDate>20260101~20260531</termDate>
         <reqCareer>신입</reqCareer>
@@ -69,9 +69,14 @@ const mockFetchWith = (xml: string) =>
 describe('GET /api/job-postings', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.JOB_API_BASE_URL = 'https://api.example.com/jobs';
-    process.env.JOB_API_KEY = 'test-key';
+    vi.stubEnv('JOB_API_BASE_URL', 'https://api.example.com/jobs');
+    vi.stubEnv('JOB_API_KEY', 'test-key');
     mockFetchWith(JOB_XML_ONE_ITEM);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
   });
 
   it('공고 목록을 반환한다', async () => {
@@ -88,6 +93,7 @@ describe('GET /api/job-postings', () => {
     expect(data[0]).toMatchObject({
       companyName: '테스트 회사',
       title: '사무보조원',
+      salary: '2,000,000원 (월급)',
     });
   });
 
@@ -149,8 +155,7 @@ describe('GET /api/job-postings', () => {
 
   it('환경변수 없으면 500을 반환한다', async () => {
     mockAuth('1');
-    delete process.env.JOB_API_BASE_URL;
-    delete process.env.JOB_API_KEY;
+    vi.unstubAllEnvs();
 
     const res = await GET(makeRequest());
     expect(res.status).toBe(500);


### PR DESCRIPTION
## 개요
이슈 #9에서 누락됐던 채용공고 관련 BFF Route Handler / Feature API 테스트를 추가한다.

## 주요 변경 사항
- `jobPostingsRoute.test.ts` — `GET /api/job-postings` BFF 8개 케이스
  - 성공 (프로필 기반 필터링 / 프로필 없음 / 북마크 표시 / 빈 결과)
  - 실패 (401 미인증 / Supabase 오류 / 환경변수 누락 / 외부 API 오류)
- `jobPostingsApi.test.ts` — `getJobPostings` Feature API 3개 케이스
  - 성공 / AbortSignal 전달 / 에러 전파

## 참고
`fast-xml-parser`가 숫자형 XML 필드를 `number`로 자동 파싱하므로 mock XML은 하드코딩 문자열로 고정함.

Closes #126