### PR TITLE
fix: 프로필 없는 계정 로그인 플래시 및 로그아웃 필터 미초기화 수정 #128

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,8 +36,7 @@ export default function Home() {
     staleTime: 1000 * 60 * 5,
   });
 
-  if (userLoading) return null;
-  if (user && profileLoading) return <DashboardView />;
+  if (userLoading || (!!user && profileLoading)) return null;
 
   if (user && profile) return <DashboardView />;
 

--- a/src/features/dashboard/hooks/useJobFitFilter.ts
+++ b/src/features/dashboard/hooks/useJobFitFilter.ts
@@ -2,8 +2,9 @@
 
 import { useState, useEffect, useMemo } from 'react';
 import type { FitLevel, JobPosting } from '@/shared/types/job';
+import { STORAGE_KEY_JOB_FITLEVEL_FILTER } from '@/shared/utils/storageKeys';
 
-const STORAGE_KEY = 'matchzoom-job-fitlevel-filter';
+const STORAGE_KEY = STORAGE_KEY_JOB_FITLEVEL_FILTER;
 
 const FIT_LEVEL_ORDER: FitLevel[] = ['잘 맞아요', '도전해볼 수 있어요'];
 

--- a/src/features/dashboard/hooks/useJobRegionFilter.ts
+++ b/src/features/dashboard/hooks/useJobRegionFilter.ts
@@ -2,8 +2,9 @@
 
 import { useState, useEffect, useMemo } from 'react';
 import type { JobPosting } from '@/shared/types/job';
+import { STORAGE_KEY_JOB_SIGUNGU_FILTER } from '@/shared/utils/storageKeys';
 
-const STORAGE_KEY = 'matchzoom-job-sigungu-filter';
+const STORAGE_KEY = STORAGE_KEY_JOB_SIGUNGU_FILTER;
 
 function extractSigungu(location: string): string | null {
   const parts = location.trim().split(/\s+/);

--- a/src/shared/hooks/useLogout.ts
+++ b/src/shared/hooks/useLogout.ts
@@ -1,6 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { logout } from '@/shared/api/authApi';
 import { CURRENT_USER_QUERY_KEY } from './useCurrentUser';
+import {
+  STORAGE_KEY_JOB_SIGUNGU_FILTER,
+  STORAGE_KEY_JOB_FITLEVEL_FILTER,
+} from '@/shared/utils/storageKeys';
 
 export function useLogout() {
   const queryClient = useQueryClient();
@@ -9,8 +13,8 @@ export function useLogout() {
     mutationFn: logout,
     onSuccess: () => {
       queryClient.setQueryData(CURRENT_USER_QUERY_KEY, null);
-      localStorage.removeItem('matchzoom-job-sigungu-filter');
-      localStorage.removeItem('matchzoom-job-fitlevel-filter');
+      localStorage.removeItem(STORAGE_KEY_JOB_SIGUNGU_FILTER);
+      localStorage.removeItem(STORAGE_KEY_JOB_FITLEVEL_FILTER);
       window.location.href = '/';
     },
   });

--- a/src/shared/hooks/useLogout.ts
+++ b/src/shared/hooks/useLogout.ts
@@ -9,6 +9,8 @@ export function useLogout() {
     mutationFn: logout,
     onSuccess: () => {
       queryClient.setQueryData(CURRENT_USER_QUERY_KEY, null);
+      localStorage.removeItem('matchzoom-job-sigungu-filter');
+      localStorage.removeItem('matchzoom-job-fitlevel-filter');
       window.location.href = '/';
     },
   });

--- a/src/shared/hooks/useTestLogout.ts
+++ b/src/shared/hooks/useTestLogout.ts
@@ -1,6 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { testLogout } from '@/shared/api/authApi';
 import { CURRENT_USER_QUERY_KEY } from './useCurrentUser';
+import {
+  STORAGE_KEY_JOB_SIGUNGU_FILTER,
+  STORAGE_KEY_JOB_FITLEVEL_FILTER,
+} from '@/shared/utils/storageKeys';
 
 export function useTestLogout() {
   const queryClient = useQueryClient();
@@ -9,8 +13,8 @@ export function useTestLogout() {
     mutationFn: testLogout,
     onSuccess: () => {
       queryClient.setQueryData(CURRENT_USER_QUERY_KEY, null);
-      localStorage.removeItem('matchzoom-job-sigungu-filter');
-      localStorage.removeItem('matchzoom-job-fitlevel-filter');
+      localStorage.removeItem(STORAGE_KEY_JOB_SIGUNGU_FILTER);
+      localStorage.removeItem(STORAGE_KEY_JOB_FITLEVEL_FILTER);
       window.location.href = '/';
     },
   });

--- a/src/shared/hooks/useTestLogout.ts
+++ b/src/shared/hooks/useTestLogout.ts
@@ -9,6 +9,8 @@ export function useTestLogout() {
     mutationFn: testLogout,
     onSuccess: () => {
       queryClient.setQueryData(CURRENT_USER_QUERY_KEY, null);
+      localStorage.removeItem('matchzoom-job-sigungu-filter');
+      localStorage.removeItem('matchzoom-job-fitlevel-filter');
       window.location.href = '/';
     },
   });

--- a/src/shared/utils/storageKeys.ts
+++ b/src/shared/utils/storageKeys.ts
@@ -1,0 +1,2 @@
+export const STORAGE_KEY_JOB_SIGUNGU_FILTER = 'matchzoom-job-sigungu-filter';
+export const STORAGE_KEY_JOB_FITLEVEL_FILTER = 'matchzoom-job-fitlevel-filter';


### PR DESCRIPTION
## 개요
계정은 있지만 프로필이 없는 사용자가 로그인 시 DashboardView가 잠깐 렌더링됐다가 LandingView로 교체되는 플래시 현상을 수정하고, 로그아웃 시 localStorage 필터가 초기화되지 않던 문제를 함께 수정합니다.

## 주요 변경 사항
- `app/page.tsx`: 유저 확인 후 프로필 로딩 중에도 `null` 반환하도록 변경 — 프로필 상태 확정 전 DashboardView를 렌더링하지 않음
- `shared/hooks/useLogout.ts`: 로그아웃 성공 시 `matchzoom-job-sigungu-filter`, `matchzoom-job-fitlevel-filter` localStorage 항목 제거
- `shared/hooks/useTestLogout.ts`: 동일하게 localStorage 필터 초기화 처리 추가

Closes #128