### PR TITLE
feat: 프로필 페이지 모바일 상단 탭 추가 및 헤더 스타일 분기 #133

### DIFF
--- a/src/features/profile/ui/ProfileSidebar.tsx
+++ b/src/features/profile/ui/ProfileSidebar.tsx
@@ -1,14 +1,9 @@
-type ProfileTab = 'result' | 'scraps';
+import { PROFILE_TAB_ITEMS, type ProfileTab } from '../utils/profileTabs';
 
 type ProfileSidebarProps = {
   activeTab: ProfileTab;
   onTabChange: (tab: ProfileTab) => void;
 };
-
-const NAV_ITEMS: { tab: ProfileTab; label: string }[] = [
-  { tab: 'result', label: '내 검사 결과' },
-  { tab: 'scraps', label: '스크랩한 공고' },
-];
 
 export function ProfileSidebar({
   activeTab,
@@ -20,15 +15,15 @@ export function ProfileSidebar({
       className="overflow-hidden rounded-lg border border-gray-200 bg-gray-50"
     >
       <ul role="list">
-        {NAV_ITEMS.map(({ tab, label }) => (
-          <li key={tab}>
+        {PROFILE_TAB_ITEMS.map(({ id, label }) => (
+          <li key={id}>
             <button
               type="button"
-              onClick={() => onTabChange(tab)}
-              aria-current={activeTab === tab ? 'page' : undefined}
+              onClick={() => onTabChange(id)}
+              aria-current={activeTab === id ? 'page' : undefined}
               className={
                 'transition-ui w-full cursor-pointer px-4 py-3 text-left text-[0.9375rem] ' +
-                (activeTab === tab
+                (activeTab === id
                   ? 'border-l-[3px] border-primary bg-primary-bg font-semibold text-primary'
                   : 'border-l-[3px] border-transparent font-normal text-gray-700 hover:bg-gray-100')
               }

--- a/src/features/profile/ui/ProfileView.tsx
+++ b/src/features/profile/ui/ProfileView.tsx
@@ -13,8 +13,7 @@ import { ScrapedJobsTab } from './ScrapedJobsTab';
 import { Skeleton } from '@/shared/ui/Skeleton';
 import { ConfirmModal } from '@/shared/ui/ConfirmModal';
 import { useCurrentUser } from '@/shared/hooks/useCurrentUser';
-
-type ProfileTab = 'result' | 'scraps';
+import { PROFILE_TAB_ITEMS, type ProfileTab } from '../utils/profileTabs';
 
 export function ProfileView() {
   const router = useRouter();
@@ -78,26 +77,33 @@ export function ProfileView() {
             aria-label="프로필 메뉴"
             className="mb-10 flex border-b border-gray-200 md:hidden"
           >
-            {(['result', 'scraps'] as ProfileTab[]).map((tab) => (
+            {PROFILE_TAB_ITEMS.map(({ id, label }) => (
               <button
-                key={tab}
+                key={id}
                 type="button"
                 role="tab"
-                aria-selected={activeTab === tab}
-                onClick={() => setActiveTab(tab)}
+                id={`tab-${id}`}
+                aria-selected={activeTab === id}
+                aria-controls={`panel-${id}`}
+                onClick={() => setActiveTab(id)}
                 className={
                   'flex-1 cursor-pointer px-4 py-3 text-[0.9375rem] font-semibold transition-colors focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-[-2px] ' +
-                  (activeTab === tab
+                  (activeTab === id
                     ? 'border-b-2 border-primary font-bold text-primary'
                     : 'border-b-2 border-transparent text-gray-500 hover:text-gray-900')
                 }
               >
-                {tab === 'result' ? '내 검사 결과' : '스크랩한 공고'}
+                {label}
               </button>
             ))}
           </div>
 
-          {activeTab === 'result' ? (
+          <div
+            role="tabpanel"
+            id="panel-result"
+            aria-labelledby="tab-result"
+            hidden={activeTab !== 'result'}
+          >
             <ProfileInfoTab
               userProfile={userProfile}
               lastSurveyDate={lastSurveyDate}
@@ -106,14 +112,20 @@ export function ProfileView() {
               matchedJobs={matchedJobs}
               onEdit={handleEdit}
             />
-          ) : (
+          </div>
+          <div
+            role="tabpanel"
+            id="panel-scraps"
+            aria-labelledby="tab-scraps"
+            hidden={activeTab !== 'scraps'}
+          >
             <ScrapedJobsTab
               jobs={scrapedJobs}
               onBookmarkToggle={(job) =>
                 handleBookmarkRemove(job.detailUrl ?? '')
               }
             />
-          )}
+          </div>
         </div>
       </div>
 

--- a/src/features/profile/ui/ProfileView.tsx
+++ b/src/features/profile/ui/ProfileView.tsx
@@ -66,13 +66,37 @@ export function ProfileView() {
   }
 
   return (
-    <div className="mx-auto max-w-[1200px] px-4 py-10 md:px-5 lg:px-6">
+    <div className="mx-auto max-w-[1200px] px-4 pt-5 pb-10 md:px-5 md:py-10 lg:px-6">
       <div className="flex gap-8">
         <div className="hidden w-[220px] shrink-0 md:block">
           <ProfileSidebar activeTab={activeTab} onTabChange={setActiveTab} />
         </div>
 
         <div className="min-w-0 flex-1">
+          <div
+            role="tablist"
+            aria-label="프로필 메뉴"
+            className="mb-10 flex border-b border-gray-200 md:hidden"
+          >
+            {(['result', 'scraps'] as ProfileTab[]).map((tab) => (
+              <button
+                key={tab}
+                type="button"
+                role="tab"
+                aria-selected={activeTab === tab}
+                onClick={() => setActiveTab(tab)}
+                className={
+                  'flex-1 cursor-pointer px-4 py-3 text-[0.9375rem] font-semibold transition-colors focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-[-2px] ' +
+                  (activeTab === tab
+                    ? 'border-b-2 border-primary font-bold text-primary'
+                    : 'border-b-2 border-transparent text-gray-500 hover:text-gray-900')
+                }
+              >
+                {tab === 'result' ? '내 검사 결과' : '스크랩한 공고'}
+              </button>
+            ))}
+          </div>
+
           {activeTab === 'result' ? (
             <ProfileInfoTab
               userProfile={userProfile}

--- a/src/features/profile/utils/profileTabs.ts
+++ b/src/features/profile/utils/profileTabs.ts
@@ -1,0 +1,6 @@
+export type ProfileTab = 'result' | 'scraps';
+
+export const PROFILE_TAB_ITEMS: { id: ProfileTab; label: string }[] = [
+  { id: 'result', label: '내 검사 결과' },
+  { id: 'scraps', label: '스크랩한 공고' },
+];

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { User } from 'lucide-react';
 
 import { useCurrentUser } from '@/shared/hooks/useCurrentUser';
@@ -10,6 +11,8 @@ import { useTestLogout } from '@/shared/hooks/useTestLogout';
 import { Button } from '@/shared/ui/Button';
 
 export function Header() {
+  const pathname = usePathname();
+  const isLanding = pathname === '/';
   const { data: user } = useCurrentUser();
   const { mutate: logout, isPending: isLogoutPending } = useLogout();
   const { mutate: testLogin, isPending: isTestLoginPending } = useTestLogin();
@@ -17,7 +20,9 @@ export function Header() {
     useTestLogout();
 
   return (
-    <header className="border-b border-primary-border bg-hero-bg">
+    <header
+      className={`border-b ${isLanding ? 'border-primary-border bg-hero-bg' : 'border-gray-100'}`}
+    >
       <div className="mx-auto flex h-14 max-w-[1200px] items-center justify-between px-4 md:h-[72px] md:px-5 lg:px-6">
         <Link
           href="/"


### PR DESCRIPTION
## 개요
프로필 페이지에서 모바일 환경 시 숨겨지던 사이드바 대신 상단 탭 UI를 추가하고, 헤더 배경·보더 스타일을 랜딩 페이지와 내부 페이지에서 다르게 적용합니다.

## 주요 변경 사항
- `ProfileView`: 모바일(`md:hidden`)에서 `role="tablist"` 상단 탭 렌더링 추가
- 탭 퍼블 가이드 준수 — `cursor-pointer`, `font-semibold`(600), `role="tab"`, `aria-selected`, `focus-visible` outline, 비활성 `border-transparent`
- 탭 상단 여백 `pt-5`(20px), 하단 마진 `mb-10`(40px) 적용
- `Header`: `usePathname`으로 경로 감지 → `/`에서만 `bg-hero-bg` + `border-primary-border`, 나머지 페이지는 `border-gray-100` (배경 없음)

Closes #133