### PR TITLE
feat: 헤더 다크/라이트 모드 토글 스위치 추가 #135

### DIFF
--- a/src/shared/hooks/useDarkMode.ts
+++ b/src/shared/hooks/useDarkMode.ts
@@ -1,26 +1,31 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 type Theme = 'dark' | 'light';
 
 export function useDarkMode() {
-  const [theme, setTheme] = useState<Theme>(() => {
-    if (typeof window === 'undefined') return 'light';
-    return document.documentElement.classList.contains('dark')
-      ? 'dark'
-      : 'light';
-  });
+  // SSR/CSR 불일치 방지: 서버와 클라이언트 모두 'light'로 시작
+  const [theme, setTheme] = useState<Theme>('light');
+  // 첫 렌더(하이드레이션)에서 DOM 덮어쓰기 방지용 플래그
+  const hasMounted = useRef(false);
 
+  // 하이드레이션 후 인라인 스크립트가 설정한 html 클래스를 읽어 실제 테마로 동기화
   useEffect(() => {
-    const root = document.documentElement;
-    if (theme === 'dark') {
-      root.classList.add('dark');
-      root.classList.remove('light');
-    } else {
-      root.classList.remove('dark');
-      root.classList.add('light');
+    setTheme(
+      document.documentElement.classList.contains('dark') ? 'dark' : 'light',
+    );
+  }, []);
+
+  // 테마 변경 시 DOM 반영 + localStorage 저장 (첫 렌더는 skip — 인라인 스크립트가 이미 설정)
+  useEffect(() => {
+    if (!hasMounted.current) {
+      hasMounted.current = true;
+      return;
     }
+    const root = document.documentElement;
+    root.classList.toggle('dark', theme === 'dark');
+    root.classList.toggle('light', theme === 'light');
     localStorage.setItem('theme', theme);
   }, [theme]);
 

--- a/src/shared/hooks/useDarkMode.ts
+++ b/src/shared/hooks/useDarkMode.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+type Theme = 'dark' | 'light';
+
+export function useDarkMode() {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window === 'undefined') return 'light';
+    return document.documentElement.classList.contains('dark')
+      ? 'dark'
+      : 'light';
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+      root.classList.remove('light');
+    } else {
+      root.classList.remove('dark');
+      root.classList.add('light');
+    }
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggle = () => setTheme((t) => (t === 'dark' ? 'light' : 'dark'));
+
+  return { theme, toggle };
+}

--- a/src/shared/hooks/useDarkMode.ts
+++ b/src/shared/hooks/useDarkMode.ts
@@ -7,6 +7,7 @@ type Theme = 'dark' | 'light';
 export function useDarkMode() {
   // SSR/CSR 불일치 방지: 서버와 클라이언트 모두 'light'로 시작
   const [theme, setTheme] = useState<Theme>('light');
+  const [mounted, setMounted] = useState(false);
   // 첫 렌더(하이드레이션)에서 DOM 덮어쓰기 방지용 플래그
   const hasMounted = useRef(false);
 
@@ -15,6 +16,7 @@ export function useDarkMode() {
     setTheme(
       document.documentElement.classList.contains('dark') ? 'dark' : 'light',
     );
+    setMounted(true);
   }, []);
 
   // 테마 변경 시 DOM 반영 + localStorage 저장 (첫 렌더는 skip — 인라인 스크립트가 이미 설정)
@@ -31,5 +33,5 @@ export function useDarkMode() {
 
   const toggle = () => setTheme((t) => (t === 'dark' ? 'light' : 'dark'));
 
-  return { theme, toggle };
+  return { theme, toggle, mounted };
 }

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -49,15 +49,11 @@ export function Header() {
                 theme === 'dark' ? '라이트 모드로 전환' : '다크 모드로 전환'
               }
               onClick={toggleTheme}
-              className={`relative h-6 w-11 shrink-0 cursor-pointer rounded-[12px] ${theme === 'dark' ? 'bg-primary' : 'bg-gray-300'}`}
-              style={{ transition: 'background-color 150ms ease' }}
+              className={`relative h-6 w-11 shrink-0 cursor-pointer rounded-[12px] transition-colors duration-[150ms] ${theme === 'dark' ? 'bg-primary' : 'bg-gray-300'}`}
             >
               <span
-                className="absolute top-[3px] flex h-[18px] w-[18px] items-center justify-center rounded-full bg-white"
-                style={{
-                  left: theme === 'dark' ? '22px' : '3px',
-                  transition: 'left 150ms ease',
-                }}
+                className="absolute top-[3px] flex h-[18px] w-[18px] items-center justify-center rounded-full bg-white transition-[left] duration-[150ms]"
+                style={{ left: theme === 'dark' ? '22px' : '3px' }}
               >
                 {theme === 'dark' ? (
                   <Moon

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -2,12 +2,13 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { User } from 'lucide-react';
+import { User, Sun, Moon } from 'lucide-react';
 
 import { useCurrentUser } from '@/shared/hooks/useCurrentUser';
 import { useLogout } from '@/shared/hooks/useLogout';
 import { useTestLogin } from '@/shared/hooks/useTestLogin';
 import { useTestLogout } from '@/shared/hooks/useTestLogout';
+import { useDarkMode } from '@/shared/hooks/useDarkMode';
 import { Button } from '@/shared/ui/Button';
 
 export function Header() {
@@ -18,6 +19,7 @@ export function Header() {
   const { mutate: testLogin, isPending: isTestLoginPending } = useTestLogin();
   const { mutate: testLogout, isPending: isTestLogoutPending } =
     useTestLogout();
+  const { theme, toggle: toggleTheme } = useDarkMode();
 
   return (
     <header
@@ -34,70 +36,115 @@ export function Header() {
           </span>
         </Link>
 
-        {!user && (
-          <nav aria-label="로그인 메뉴" className="flex items-center gap-2">
-            <Button
-              variant="ghost"
-              size="md"
-              disabled={isTestLoginPending}
-              onClick={() => testLogin()}
+        <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2.5">
+            <span className="text-[0.75rem] font-semibold leading-none text-gray-500">
+              {theme === 'dark' ? '다크 모드' : '라이트 모드'}
+            </span>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={theme === 'dark'}
+              aria-label={
+                theme === 'dark' ? '라이트 모드로 전환' : '다크 모드로 전환'
+              }
+              onClick={toggleTheme}
+              className={`relative h-6 w-11 shrink-0 cursor-pointer rounded-[12px] ${theme === 'dark' ? 'bg-primary' : 'bg-gray-300'}`}
+              style={{ transition: 'background-color 150ms ease' }}
             >
-              {isTestLoginPending ? '로그인 중...' : '테스트 계정으로 로그인'}
-            </Button>
-            <Button
-              variant="secondary"
-              size="md"
-              onClick={() => {
-                window.location.href = '/api/oauth/kakao/authorize';
-              }}
-            >
-              로그인
-            </Button>
-          </nav>
-        )}
+              <span
+                className="absolute top-[3px] flex h-[18px] w-[18px] items-center justify-center rounded-full bg-white"
+                style={{
+                  left: theme === 'dark' ? '22px' : '3px',
+                  transition: 'left 150ms ease',
+                }}
+              >
+                {theme === 'dark' ? (
+                  <Moon
+                    size={10}
+                    strokeWidth={1.5}
+                    className="text-primary"
+                    aria-hidden="true"
+                  />
+                ) : (
+                  <Sun
+                    size={10}
+                    strokeWidth={1.5}
+                    className="text-gray-400"
+                    aria-hidden="true"
+                  />
+                )}
+              </span>
+            </button>
+          </div>
 
-        {user && user.isTestUser && (
-          <nav
-            aria-label="테스트 계정 메뉴"
-            className="flex items-center gap-3"
-          >
-            <Link
-              href="/profile"
-              aria-label="프로필 페이지로 이동"
-              className="transition-ui flex h-9 w-9 cursor-pointer items-center justify-center rounded-sm border border-gray-200 bg-gray-50 text-gray-700 hover:bg-gray-100"
-            >
-              <User size={20} strokeWidth={1.5} aria-hidden="true" />
-            </Link>
-            <Button
-              variant="ghost"
-              size="md"
-              disabled={isTestLogoutPending}
-              onClick={() => testLogout()}
-            >
-              {isTestLogoutPending ? '로그아웃 중...' : '테스트 계정 로그아웃'}
-            </Button>
-          </nav>
-        )}
+          {!user && (
+            <nav aria-label="로그인 메뉴" className="flex items-center gap-2">
+              <Button
+                variant="ghost"
+                size="md"
+                disabled={isTestLoginPending}
+                onClick={() => testLogin()}
+              >
+                {isTestLoginPending ? '로그인 중...' : '테스트 계정으로 로그인'}
+              </Button>
+              <Button
+                variant="secondary"
+                size="md"
+                onClick={() => {
+                  window.location.href = '/api/oauth/kakao/authorize';
+                }}
+              >
+                로그인
+              </Button>
+            </nav>
+          )}
 
-        {user && !user.isTestUser && (
-          <nav aria-label="사용자 메뉴" className="flex items-center gap-3">
-            <Link
-              href="/profile"
-              aria-label="프로필 페이지로 이동"
-              className="transition-ui flex h-9 w-9 cursor-pointer items-center justify-center rounded-sm border border-gray-200 bg-gray-50 text-gray-700 hover:bg-gray-100"
+          {user && user.isTestUser && (
+            <nav
+              aria-label="테스트 계정 메뉴"
+              className="flex items-center gap-3"
             >
-              <User size={20} strokeWidth={1.5} aria-hidden="true" />
-            </Link>
-            <Button
-              variant="secondary"
-              size="md"
-              disabled={isLogoutPending}
-              onClick={() => logout()}
-            >
-              {isLogoutPending ? '로그아웃 중...' : '로그아웃'}
-            </Button>
-          </nav>
-        )}
+              <Link
+                href="/profile"
+                aria-label="프로필 페이지로 이동"
+                className="transition-ui flex h-9 w-9 cursor-pointer items-center justify-center rounded-sm border border-gray-200 bg-gray-50 text-gray-700 hover:bg-gray-100"
+              >
+                <User size={20} strokeWidth={1.5} aria-hidden="true" />
+              </Link>
+              <Button
+                variant="ghost"
+                size="md"
+                disabled={isTestLogoutPending}
+                onClick={() => testLogout()}
+              >
+                {isTestLogoutPending
+                  ? '로그아웃 중...'
+                  : '테스트 계정 로그아웃'}
+              </Button>
+            </nav>
+          )}
+
+          {user && !user.isTestUser && (
+            <nav aria-label="사용자 메뉴" className="flex items-center gap-3">
+              <Link
+                href="/profile"
+                aria-label="프로필 페이지로 이동"
+                className="transition-ui flex h-9 w-9 cursor-pointer items-center justify-center rounded-sm border border-gray-200 bg-gray-50 text-gray-700 hover:bg-gray-100"
+              >
+                <User size={20} strokeWidth={1.5} aria-hidden="true" />
+              </Link>
+              <Button
+                variant="secondary"
+                size="md"
+                disabled={isLogoutPending}
+                onClick={() => logout()}
+              >
+                {isLogoutPending ? '로그아웃 중...' : '로그아웃'}
+              </Button>
+            </nav>
+          )}
+        </div>
       </div>
     </header>
   );

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -19,7 +19,7 @@ export function Header() {
   const { mutate: testLogin, isPending: isTestLoginPending } = useTestLogin();
   const { mutate: testLogout, isPending: isTestLogoutPending } =
     useTestLogout();
-  const { theme, toggle: toggleTheme } = useDarkMode();
+  const { theme, toggle: toggleTheme, mounted: themeMounted } = useDarkMode();
 
   return (
     <header
@@ -38,9 +38,11 @@ export function Header() {
 
         <div className="flex items-center gap-2">
           <div className="flex items-center gap-2.5">
-            <span className="text-[0.75rem] font-semibold leading-none text-gray-500">
-              {theme === 'dark' ? '다크 모드' : '라이트 모드'}
-            </span>
+            {themeMounted && (
+              <span className="text-[0.75rem] font-semibold leading-none text-gray-500">
+                {theme === 'dark' ? '다크 모드' : '라이트 모드'}
+              </span>
+            )}
             <button
               type="button"
               role="switch"


### PR DESCRIPTION
## 개요
헤더 우측에 다크/라이트 모드 전환 토글 스위치를 추가합니다. 로그인 상태와 무관하게 항상 표시되며, 시스템 설정 기반 초기값으로 시작합니다.

## 주요 변경 사항
- `shared/hooks/useDarkMode.ts` 신규 — 초기값을 DOM 클래스에서 읽어 FOUC 방지, 토글 시 `classList` 갱신 + `localStorage('theme')` 저장
- `widgets/header/ui/Header.tsx` — 우측 영역을 wrapper div로 묶고 맨 앞에 토글 스위치 배치. `role="switch"` + 슬라이딩 thumb(Moon/Sun 아이콘) + 모드명 레이블 구성

Closes #135
Related to #125