### PR TITLE
fix: 랜딩 페이지 로딩 중 CLS 개선 #137

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,9 +36,19 @@ export default function Home() {
     staleTime: 1000 * 60 * 5,
   });
 
-  if (userLoading || (!!user && profileLoading)) return null;
+  const isLoading = userLoading || (!!user && profileLoading);
 
-  if (user && profile) return <DashboardView />;
+  if (!isLoading && user && profile) return <DashboardView />;
 
-  return <LandingView isLoggedIn={!!user} />;
+  return (
+    <div
+      className={
+        isLoading
+          ? 'pointer-events-none [&_button]:opacity-0 [&_h1]:text-transparent [&_h3]:text-transparent [&_img]:opacity-0 [&_p]:text-transparent [&_span]:opacity-0 [&_.step-image-frame]:opacity-0'
+          : undefined
+      }
+    >
+      <LandingView isLoggedIn={!isLoading && !!user} />
+    </div>
+  );
 }

--- a/src/features/landing/ui/ServiceIntroSection.tsx
+++ b/src/features/landing/ui/ServiceIntroSection.tsx
@@ -98,7 +98,7 @@ export function ServiceIntroSection() {
 
               <div className="hidden shrink-0 lg:block">
                 <div
-                  className={`h-[300px] w-[560px] overflow-hidden rounded-lg border border-gray-200 bg-white p-1.5 ${step.innerPad ?? ''}`}
+                  className={`step-image-frame h-[300px] w-[560px] overflow-hidden rounded-lg border border-gray-200 bg-white p-1.5 ${step.innerPad ?? ''}`}
                 >
                   <div className="relative h-full w-full overflow-hidden rounded">
                     {step.image ? (


### PR DESCRIPTION
## 개요

로그인 상태 확인 중 `return null`로 인해 main 영역이 비었다가 채워지면서 발생하는 CLS를 개선한다. DOM 교체 없이 CSS 클래스 변경만으로 로딩 상태를 처리한다.

## 주요 변경 사항

- `page.tsx`: 로딩 중 별도 컴포넌트 교체 대신 동일한 `<LandingView>` wrapper div에 CSS 클래스(`text-transparent`, `opacity-0`)만 추가/제거
  - 텍스트·이미지·버튼은 투명 처리, 섹션 배경색은 그대로 노출
  - 로딩 완료 시 `className`만 변경 → DOM 교체 없음 → 레이아웃 이동 없음
- `ServiceIntroSection.tsx`: 이미지 컨테이너에 `step-image-frame` 클래스 추가 → 로딩 중 테두리/배경 숨김 가능하도록 타겟 제공

Closes #137