### PR TITLE
🚩feat: 메인 Server Component 전환 및 헤더 인증 플래시 제거 #139

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { Button } from '@/shared/ui/Button';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-6 px-4 text-center">
+      <div className="flex flex-col gap-2">
+        <p className="text-[1rem] font-semibold text-gray-900">
+          오류가 발생했어요
+        </p>
+        <p className="text-[0.875rem] text-gray-500">
+          {error.message || '잠시 후 다시 시도해 주세요.'}
+        </p>
+      </div>
+      <Button variant="secondary" onClick={reset}>
+        다시 시도
+      </Button>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,14 @@
 import type { Metadata } from 'next';
+import { cookies } from 'next/headers';
 import { QueryProvider } from '@/shared/providers/query-provider';
 import { NavigationTracker } from '@/shared/providers/NavigationTracker';
 import { Header } from '@/widgets/header';
 import { Footer } from '@/widgets/footer';
+import { verifySession } from '@/shared/utils/session';
+import { AUTH_COOKIE_KEYS } from '@/shared/utils/authCookies';
+import { supabaseFetch } from '@/shared/api/supabaseFetch';
+import type { CurrentUser } from '@/shared/types/user';
+import { TEST_USER_ID, TEST_USER } from '@/shared/utils/testUser';
 import './globals.css';
 
 const siteUrl =
@@ -41,11 +47,35 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+async function getInitialUser(): Promise<CurrentUser | null> {
+  try {
+    const cookieStore = await cookies();
+    const token = cookieStore.get(AUTH_COOKIE_KEYS.SESSION)?.value;
+    if (!token) return null;
+
+    const session = await verifySession(token);
+    if (!session?.userId) return null;
+
+    if (session.userId === TEST_USER_ID) return TEST_USER;
+
+    const rows = await supabaseFetch<
+      Array<{ id: number; nickname: string; created_at: string }>
+    >(
+      `/rest/v1/users?id=eq.${session.userId}&select=id,nickname,created_at&limit=1`,
+    );
+    return rows[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const initialUser = await getInitialUser();
+
   return (
     <html lang="ko" suppressHydrationWarning>
       <head>
@@ -62,7 +92,7 @@ export default function RootLayout({
         </a>
         <QueryProvider>
           <NavigationTracker />
-          <Header />
+          <Header initialUser={initialUser} />
           <main id="main-content" className="flex-1">
             {children}
           </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,54 +1,32 @@
-'use client';
+import { Suspense } from 'react';
+import { cookies } from 'next/headers';
+import { verifySession } from '@/shared/utils/session';
+import { AUTH_COOKIE_KEYS } from '@/shared/utils/authCookies';
+import { supabaseFetch } from '@/shared/api/supabaseFetch';
+import { DashboardView, DashboardSkeleton } from '@/features/dashboard';
+import { LandingPage } from '@/features/landing';
 
-import { useRouter } from 'next/navigation';
-import { useQuery } from '@tanstack/react-query';
-import { useCurrentUser } from '@/shared/hooks/useCurrentUser';
-import { getProfile } from '@/features/profile/api/profileApi';
-import { DashboardView } from '@/features/dashboard';
-import { HeroSection, ServiceIntroSection } from '@/features/landing';
+export default async function Home() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(AUTH_COOKIE_KEYS.SESSION)?.value;
+  const session = token ? await verifySession(token) : null;
 
-function LandingView({ isLoggedIn }: { isLoggedIn: boolean }) {
-  const router = useRouter();
+  if (session?.userId) {
+    const rows = await supabaseFetch<{ id: number }[]>(
+      `/rest/v1/profiles?user_id=eq.${session.userId}&select=id&limit=1`,
+    );
+    const hasProfile = rows.length > 0;
 
-  const handleCtaClick = () => {
-    if (isLoggedIn) {
-      router.push('/survey');
-    } else {
-      window.location.href = '/api/oauth/kakao/authorize';
+    if (hasProfile) {
+      return (
+        <Suspense fallback={<DashboardSkeleton />}>
+          <DashboardView />
+        </Suspense>
+      );
     }
-  };
 
-  return (
-    <>
-      <HeroSection onCtaClick={handleCtaClick} />
-      <ServiceIntroSection />
-    </>
-  );
-}
+    return <LandingPage isLoggedIn={true} />;
+  }
 
-export default function Home() {
-  const { data: user, isLoading: userLoading } = useCurrentUser();
-
-  const { data: profile, isLoading: profileLoading } = useQuery({
-    queryKey: ['profile', user?.id],
-    queryFn: getProfile,
-    enabled: !!user,
-    staleTime: 1000 * 60 * 5,
-  });
-
-  const isLoading = userLoading || (!!user && profileLoading);
-
-  if (!isLoading && user && profile) return <DashboardView />;
-
-  return (
-    <div
-      className={
-        isLoading
-          ? 'pointer-events-none [&_button]:opacity-0 [&_h1]:text-transparent [&_h3]:text-transparent [&_img]:opacity-0 [&_p]:text-transparent [&_span]:opacity-0 [&_.step-image-frame]:opacity-0'
-          : undefined
-      }
-    >
-      <LandingView isLoggedIn={!isLoading && !!user} />
-    </div>
-  );
+  return <LandingPage isLoggedIn={false} />;
 }

--- a/src/features/dashboard/index.ts
+++ b/src/features/dashboard/index.ts
@@ -1,1 +1,2 @@
 export { DashboardView } from './ui/DashboardView';
+export { DashboardSkeleton } from './ui/DashboardSkeleton';

--- a/src/features/dashboard/ui/DashboardSkeleton.tsx
+++ b/src/features/dashboard/ui/DashboardSkeleton.tsx
@@ -1,0 +1,20 @@
+export function DashboardSkeleton() {
+  return (
+    <div className="animate-pulse py-10 md:py-16">
+      <div className="mx-auto flex max-w-[1200px] flex-col gap-[60px] px-4 md:px-5 lg:px-6">
+        {/* AIResultCard 스켈레톤 */}
+        <div className="h-[360px] rounded-2xl bg-gray-100" />
+
+        {/* JobListSection 스켈레톤 */}
+        <div className="flex flex-col gap-4">
+          <div className="h-10 w-48 rounded-lg bg-gray-100" />
+          <div className="flex flex-col gap-3">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="h-28 rounded-xl bg-gray-100" />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/landing/index.ts
+++ b/src/features/landing/index.ts
@@ -2,3 +2,4 @@ export { HeroSection } from './ui/HeroSection';
 export { ServiceIntroSection } from './ui/ServiceIntroSection';
 export { TrustSection } from './ui/TrustSection';
 export { LandingBottomCta } from './ui/LandingBottomCta';
+export { LandingPage } from './ui/LandingPage';

--- a/src/features/landing/ui/LandingPage.tsx
+++ b/src/features/landing/ui/LandingPage.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { HeroSection } from './HeroSection';
+import { ServiceIntroSection } from './ServiceIntroSection';
+
+type LandingPageProps = {
+  isLoggedIn: boolean;
+};
+
+export function LandingPage({ isLoggedIn }: LandingPageProps) {
+  const router = useRouter();
+
+  const handleCtaClick = () => {
+    if (isLoggedIn) {
+      router.push('/survey');
+    } else {
+      window.location.href = '/api/oauth/kakao/authorize';
+    }
+  };
+
+  return (
+    <>
+      <HeroSection onCtaClick={handleCtaClick} />
+      <ServiceIntroSection />
+    </>
+  );
+}

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -10,11 +10,18 @@ import { useTestLogin } from '@/shared/hooks/useTestLogin';
 import { useTestLogout } from '@/shared/hooks/useTestLogout';
 import { useDarkMode } from '@/shared/hooks/useDarkMode';
 import { Button } from '@/shared/ui/Button';
+import type { CurrentUser } from '@/shared/types/user';
 
-export function Header() {
+type HeaderProps = {
+  initialUser?: CurrentUser | null;
+};
+
+export function Header({ initialUser }: HeaderProps) {
   const pathname = usePathname();
   const isLanding = pathname === '/';
-  const { data: user } = useCurrentUser();
+  const { data: fetchedUser } = useCurrentUser();
+  // fetchedUser가 undefined(로딩 중)이면 서버에서 내려준 initialUser 사용
+  const user = fetchedUser ?? initialUser;
   const { mutate: logout, isPending: isLogoutPending } = useLogout();
   const { mutate: testLogin, isPending: isTestLoginPending } = useTestLogin();
   const { mutate: testLogout, isPending: isTestLogoutPending } =


### PR DESCRIPTION
## 개요

메인 페이지 LCP 14.2초 문제 해결을 위한 1차 개선 작업.
비로그인 유저 랜딩 페이지 즉시 SSR 렌더 + 헤더 hydration 플래시 제거.

> **WIP**: 로그인 유저 대시보드의 Suspense 동작(useSuspenseQuery 전환)은 미완료.

## 주요 변경 사항

### `app/page.tsx` — async Server Component 전환
- 쿠키 기반 session 서버 검증 후 세 가지 뷰 분기

  | 조건 | 뷰 |
  |------|----|
  | 로그인 + 프로필 있음 | `<Suspense><DashboardView /></Suspense>` |
  | 로그인 + 프로필 없음 | `<LandingPage isLoggedIn={true} />` |
  | 비로그인 | `<LandingPage isLoggedIn={false} />` |

- 비로그인 유저는 JS 없이도 완성된 HTML 즉시 수신 → LCP 대폭 단축

### `app/layout.tsx` — 유저 정보 서버 조회
- session 쿠키 검증 후 Supabase에서 유저 조회
- `initialUser`를 Header prop으로 전달

### `widgets/header/ui/Header.tsx` — 플래시 제거
- `fetchedUser ?? initialUser` 패턴으로 hydration 전까지 서버 데이터 사용
- 새로고침 시 로그인 버튼 깜빡임 현상 제거

### 신규 파일
- `app/error.tsx` — 라우트 레벨 에러 바운더리
- `features/landing/ui/LandingPage.tsx` — `useRouter` 담당 클라이언트 컴포넌트 분리
- `features/dashboard/ui/DashboardSkeleton.tsx` — Suspense fallback 스켈레톤

## 미완료 (후속 PR 예정)

- `useDashboard`, `useJobPostings` 의 `useQuery` → `useSuspenseQuery` 전환
  - 현재 Suspense wrapper는 구조만 갖춰진 상태, skeleton 실제 노출 안 됨
- 로그인 유저 LCP 추가 개선

Closes #139