### PR TITLE
fix: 세션 중복 제거 및 테스트 유저 대시보드 즉시 진입 수정 #141

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,14 +1,12 @@
 import type { Metadata } from 'next';
-import { cookies } from 'next/headers';
 import { QueryProvider } from '@/shared/providers/query-provider';
 import { NavigationTracker } from '@/shared/providers/NavigationTracker';
 import { Header } from '@/widgets/header';
 import { Footer } from '@/widgets/footer';
-import { verifySession } from '@/shared/utils/session';
-import { AUTH_COOKIE_KEYS } from '@/shared/utils/authCookies';
 import { supabaseFetch } from '@/shared/api/supabaseFetch';
+import { getServerSession } from '@/shared/utils/serverSession';
 import type { CurrentUser } from '@/shared/types/user';
-import { TEST_USER_ID, TEST_USER } from '@/shared/utils/testUser';
+import { TEST_USER } from '@/shared/utils/testUser';
 import './globals.css';
 
 const siteUrl =
@@ -49,14 +47,9 @@ export const metadata: Metadata = {
 
 async function getInitialUser(): Promise<CurrentUser | null> {
   try {
-    const cookieStore = await cookies();
-    const token = cookieStore.get(AUTH_COOKIE_KEYS.SESSION)?.value;
-    if (!token) return null;
-
-    const session = await verifySession(token);
-    if (!session?.userId) return null;
-
-    if (session.userId === TEST_USER_ID) return TEST_USER;
+    const session = await getServerSession();
+    if (!session) return null;
+    if (session.isTestUser) return TEST_USER;
 
     const rows = await supabaseFetch<
       Array<{ id: number; nickname: string; created_at: string }>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,21 +1,18 @@
 import { Suspense } from 'react';
-import { cookies } from 'next/headers';
-import { verifySession } from '@/shared/utils/session';
-import { AUTH_COOKIE_KEYS } from '@/shared/utils/authCookies';
 import { supabaseFetch } from '@/shared/api/supabaseFetch';
+import { getServerSession } from '@/shared/utils/serverSession';
 import { DashboardView, DashboardSkeleton } from '@/features/dashboard';
 import { LandingPage } from '@/features/landing';
 
 export default async function Home() {
-  const cookieStore = await cookies();
-  const token = cookieStore.get(AUTH_COOKIE_KEYS.SESSION)?.value;
-  const session = token ? await verifySession(token) : null;
+  const session = await getServerSession();
 
   if (session?.userId) {
-    const rows = await supabaseFetch<{ id: number }[]>(
-      `/rest/v1/profiles?user_id=eq.${session.userId}&select=id&limit=1`,
-    );
-    const hasProfile = rows.length > 0;
+    const hasProfile =
+      session.isTestUser ||
+      (await supabaseFetch<{ id: number }[]>(
+        `/rest/v1/profiles?user_id=eq.${session.userId}&select=id&limit=1`,
+      ).then((rows) => rows.length > 0));
 
     if (hasProfile) {
       return (

--- a/src/features/dashboard/hooks/useDashboard.ts
+++ b/src/features/dashboard/hooks/useDashboard.ts
@@ -1,21 +1,22 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { getProfile } from '@/features/profile/api/profileApi';
-import { useMatchResult } from '@/features/match/hooks/useMatchResult';
+import { getMatchResult } from '@/features/match/api/matchApi';
 import {
   toPersonalityAxes,
   toMatchedJobs,
 } from '@/features/match/utils/convert';
 
 export function useDashboard() {
-  const { data: profile, isLoading: isProfileLoading } = useQuery({
+  const { data: profile } = useSuspenseQuery({
     queryKey: ['profile'],
     queryFn: getProfile,
   });
 
-  const { data: matchResult, isLoading: isMatchLoading } = useMatchResult({
-    enabled: !!profile,
+  const { data: matchResult } = useSuspenseQuery({
+    queryKey: ['match-result'],
+    queryFn: getMatchResult,
   });
 
   const profileProvinces = profile?.region_primary
@@ -24,7 +25,6 @@ export function useDashboard() {
 
   return {
     userName: profile?.name ?? '',
-    isLoading: isProfileLoading || isMatchLoading,
     personalityAxes: matchResult
       ? toPersonalityAxes(matchResult.radar_chart)
       : [],

--- a/src/features/dashboard/hooks/useJobPostings.ts
+++ b/src/features/dashboard/hooks/useJobPostings.ts
@@ -1,11 +1,10 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
-
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { getJobPostings } from '../api/jobPostingsApi';
 
 export function useJobPostings() {
-  return useQuery({
+  return useSuspenseQuery({
     queryKey: ['job-postings'],
     queryFn: ({ signal }) => getJobPostings(signal),
     staleTime: 5 * 60 * 1000,

--- a/src/features/dashboard/ui/DashboardView.tsx
+++ b/src/features/dashboard/ui/DashboardView.tsx
@@ -12,13 +12,12 @@ import { ConfirmModal } from '@/shared/ui/ConfirmModal';
 export function DashboardView() {
   const {
     userName,
-    isLoading: isDashboardLoading,
     personalityAxes,
     personalitySummary,
     matchedJobs,
     profileProvinces,
   } = useDashboard();
-  const { data: postings = [], isPending: isJobsLoading } = useJobPostings();
+  const { data: postings } = useJobPostings();
   const {
     availableSigungu,
     selectedSigungu,
@@ -49,7 +48,6 @@ export function DashboardView() {
             axes={personalityAxes}
             summary={personalitySummary}
             jobs={matchedJobs}
-            isLoading={isDashboardLoading}
           />
         </section>
 
@@ -61,8 +59,6 @@ export function DashboardView() {
             userName={userName}
             postings={filteredPostings}
             onBookmarkToggle={handleBookmarkToggle}
-            isLoading={isJobsLoading}
-            isLoadingUser={isDashboardLoading}
             sigunguList={availableSigungu}
             selectedSigungu={selectedSigungu}
             onSelectSigungu={handleSelectSigungu}

--- a/src/shared/hooks/useTestLogin.ts
+++ b/src/shared/hooks/useTestLogin.ts
@@ -1,14 +1,11 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { testLogin } from '@/shared/api/authApi';
-import { CURRENT_USER_QUERY_KEY } from './useCurrentUser';
 
 export function useTestLogin() {
-  const queryClient = useQueryClient();
-
   return useMutation({
     mutationFn: testLogin,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: CURRENT_USER_QUERY_KEY });
+      window.location.href = '/';
     },
   });
 }

--- a/src/shared/utils/serverSession.ts
+++ b/src/shared/utils/serverSession.ts
@@ -1,0 +1,34 @@
+import { cache } from 'react';
+import { cookies } from 'next/headers';
+import { verifySession } from './session';
+import { AUTH_COOKIE_KEYS } from './authCookies';
+import { TEST_USER_ID } from './testUser';
+
+export type ServerSession = {
+  userId: string;
+  isTestUser: boolean;
+};
+
+/**
+ * 서버 컴포넌트에서 session JWT를 검증하고 userId를 반환한다.
+ * React.cache로 감싸져 있어 같은 요청 내에서 layout/page가 각자 호출해도 한 번만 실행된다.
+ */
+export const getServerSession = cache(
+  async (): Promise<ServerSession | null> => {
+    try {
+      const cookieStore = await cookies();
+      const token = cookieStore.get(AUTH_COOKIE_KEYS.SESSION)?.value;
+      if (!token) return null;
+
+      const session = await verifySession(token);
+      if (!session?.userId) return null;
+
+      return {
+        userId: session.userId,
+        isTestUser: session.userId === TEST_USER_ID,
+      };
+    } catch {
+      return null;
+    }
+  },
+);


### PR DESCRIPTION
## 개요

PR #140에서 `page.tsx`를 Server Component로 전환한 이후 발생한 두 가지 문제를 수정.

## 주요 변경 사항

### `shared/utils/serverSession.ts` (신규)

`React.cache()`로 래핑한 `getServerSession()` 함수 추가.
같은 요청 내에서 `layout.tsx`와 `page.tsx`가 각자 호출해도 쿠키 읽기 + JWT 검증이 **1회만** 실행된다.

```ts
export const getServerSession = cache(async (): Promise<ServerSession | null> => {
  // 쿠키 읽기 + verifySession() → { userId, isTestUser }
});
```

### `page.tsx` — 테스트 유저 대시보드 즉시 진입

테스트 유저는 Supabase DB에 실제 프로필 레코드가 없어 항상 랜딩으로 분기되던 버그 수정.

```ts
const hasProfile =
  session.isTestUser ||   // true이면 Supabase 조회 생략
  (await supabaseFetch<...>(...).then((rows) => rows.length > 0));
```

### `useTestLogin` — 로그인 즉시 대시보드 진입

`invalidateQueries`(클라이언트 캐시 갱신)만으로는 Server Component가 재실행되지 않아
로그인 후 새로고침해야만 대시보드가 보이던 문제 수정.

```ts
// 변경 전
queryClient.invalidateQueries({ queryKey: CURRENT_USER_QUERY_KEY });

// 변경 후
window.location.href = '/';  // 완전 재내비게이션 → 서버 재실행
```

Closes #141