### PR TITLE
fix: hydrationBoundary 도입으로 서버 데이터 중복 fetch 제거 및 queryClient 싱글턴 버그 수정 #145

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -89,7 +89,7 @@ export default async function RootLayout({
           }}
         />
       </head>
-      <body className="flex min-h-screen flex-col">
+      <body className="flex min-h-screen flex-col" suppressHydrationWarning>
         <a href="#main-content" className="skip-link">
           본문 바로가기
         </a>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,31 +1,46 @@
 import { Suspense } from 'react';
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from '@tanstack/react-query';
 import { supabaseFetch } from '@/shared/api/supabaseFetch';
 import { getServerSession } from '@/shared/utils/serverSession';
 import { DashboardView, DashboardSkeleton } from '@/features/dashboard';
 import { LandingPage } from '@/features/landing';
+import { TEST_PROFILE, TEST_MATCH } from '@/shared/utils/testUser';
+import type { Profile } from '@/shared/types/profile';
+import type { MatchResult } from '@/shared/types/match';
+
+async function getDashboardData(userId: string) {
+  const [profileRows, matchRows] = await Promise.all([
+    supabaseFetch<Profile[]>(`/rest/v1/profiles?user_id=eq.${userId}&select=*`),
+    supabaseFetch<MatchResult[]>(
+      `/rest/v1/match_results?user_id=eq.${userId}&select=*`,
+    ),
+  ]);
+  return { profile: profileRows[0] ?? null, matchResult: matchRows[0] ?? null };
+}
 
 export default async function Home() {
   const session = await getServerSession();
 
   if (session) {
-    if (session.isTestUser) {
-      return (
-        <Suspense fallback={<DashboardSkeleton />}>
-          <DashboardView />
-        </Suspense>
-      );
-    }
+    const { profile, matchResult } = session.isTestUser
+      ? { profile: TEST_PROFILE, matchResult: TEST_MATCH }
+      : await getDashboardData(session.userId);
 
-    const rows = await supabaseFetch<{ id: number }[]>(
-      `/rest/v1/profiles?user_id=eq.${session.userId}&select=id&limit=1`,
-    );
-    const hasProfile = rows.length > 0;
+    if (profile) {
+      const queryClient = new QueryClient();
+      queryClient.setQueryData(['profile'], profile);
+      queryClient.setQueryData(['match-result'], matchResult);
 
-    if (hasProfile) {
       return (
-        <Suspense fallback={<DashboardSkeleton />}>
-          <DashboardView />
-        </Suspense>
+        <HydrationBoundary state={dehydrate(queryClient)}>
+          <Suspense fallback={<DashboardSkeleton />}>
+            <DashboardView />
+          </Suspense>
+        </HydrationBoundary>
       );
     }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from 'react';
 import {
   dehydrate,
   HydrationBoundary,
@@ -6,7 +5,7 @@ import {
 } from '@tanstack/react-query';
 import { supabaseFetch } from '@/shared/api/supabaseFetch';
 import { getServerSession } from '@/shared/utils/serverSession';
-import { DashboardView, DashboardSkeleton } from '@/features/dashboard';
+import { DashboardView } from '@/features/dashboard';
 import { LandingPage } from '@/features/landing';
 import { TEST_PROFILE, TEST_MATCH } from '@/shared/utils/testUser';
 import type { Profile } from '@/shared/types/profile';
@@ -37,9 +36,7 @@ export default async function Home() {
 
       return (
         <HydrationBoundary state={dehydrate(queryClient)}>
-          <Suspense fallback={<DashboardSkeleton />}>
-            <DashboardView />
-          </Suspense>
+          <DashboardView />
         </HydrationBoundary>
       );
     }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,8 @@ import { supabaseFetch } from '@/shared/api/supabaseFetch';
 import { getServerSession } from '@/shared/utils/serverSession';
 import { DashboardView, DashboardSkeleton } from '@/features/dashboard';
 import { LandingPage } from '@/features/landing';
+import { PROFILE_QUERY_KEY } from '@/features/profile/hooks/useProfile';
+import { MATCH_RESULT_QUERY_KEY } from '@/features/match/hooks/useMatchResult';
 import { TEST_PROFILE, TEST_MATCH } from '@/shared/utils/testUser';
 import type { Profile } from '@/shared/types/profile';
 import type { MatchResult } from '@/shared/types/match';
@@ -32,8 +34,8 @@ export default async function Home() {
 
     if (profile) {
       const queryClient = new QueryClient();
-      queryClient.setQueryData(['profile'], profile);
-      queryClient.setQueryData(['match-result'], matchResult);
+      queryClient.setQueryData(PROFILE_QUERY_KEY, profile);
+      queryClient.setQueryData(MATCH_RESULT_QUERY_KEY, matchResult);
 
       return (
         <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/features/dashboard/hooks/useDashboard.ts
+++ b/src/features/dashboard/hooks/useDashboard.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { getProfile } from '@/features/profile/api/profileApi';
 import { getMatchResult } from '@/features/match/api/matchApi';
 import {
@@ -9,12 +9,12 @@ import {
 } from '@/features/match/utils/convert';
 
 export function useDashboard() {
-  const { data: profile } = useSuspenseQuery({
+  const { data: profile } = useQuery({
     queryKey: ['profile'],
     queryFn: getProfile,
   });
 
-  const { data: matchResult } = useSuspenseQuery({
+  const { data: matchResult } = useQuery({
     queryKey: ['match-result'],
     queryFn: getMatchResult,
   });

--- a/src/features/dashboard/hooks/useDashboard.ts
+++ b/src/features/dashboard/hooks/useDashboard.ts
@@ -2,7 +2,9 @@
 
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { getProfile } from '@/features/profile/api/profileApi';
+import { PROFILE_QUERY_KEY } from '@/features/profile/hooks/useProfile';
 import { getMatchResult } from '@/features/match/api/matchApi';
+import { MATCH_RESULT_QUERY_KEY } from '@/features/match/hooks/useMatchResult';
 import {
   toPersonalityAxes,
   toMatchedJobs,
@@ -10,12 +12,12 @@ import {
 
 export function useDashboard() {
   const { data: profile } = useSuspenseQuery({
-    queryKey: ['profile'],
+    queryKey: PROFILE_QUERY_KEY,
     queryFn: getProfile,
   });
 
   const { data: matchResult } = useSuspenseQuery({
-    queryKey: ['match-result'],
+    queryKey: MATCH_RESULT_QUERY_KEY,
     queryFn: getMatchResult,
   });
 

--- a/src/features/dashboard/hooks/useJobPostings.ts
+++ b/src/features/dashboard/hooks/useJobPostings.ts
@@ -1,10 +1,10 @@
 'use client';
 
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { getJobPostings } from '../api/jobPostingsApi';
 
 export function useJobPostings() {
-  return useSuspenseQuery({
+  return useQuery({
     queryKey: ['job-postings'],
     queryFn: ({ signal }) => getJobPostings(signal),
     staleTime: 5 * 60 * 1000,

--- a/src/features/dashboard/ui/DashboardView.tsx
+++ b/src/features/dashboard/ui/DashboardView.tsx
@@ -23,7 +23,7 @@ export function DashboardView() {
     selectedSigungu,
     filteredPostings: regionFiltered,
     handleSelectSigungu,
-  } = useJobRegionFilter(postings, profileProvinces);
+  } = useJobRegionFilter(postings ?? [], profileProvinces);
   const {
     availableFitLevels,
     selectedFitLevel,

--- a/src/features/match/hooks/useGenerateMatch.ts
+++ b/src/features/match/hooks/useGenerateMatch.ts
@@ -2,6 +2,7 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { generateMatch } from '../api/matchApi';
+import { MATCH_RESULT_QUERY_KEY } from './useMatchResult';
 
 export function useGenerateMatch() {
   const queryClient = useQueryClient();
@@ -9,7 +10,7 @@ export function useGenerateMatch() {
   return useMutation({
     mutationFn: () => generateMatch(),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['match-result'] });
+      queryClient.invalidateQueries({ queryKey: MATCH_RESULT_QUERY_KEY });
     },
   });
 }

--- a/src/features/match/hooks/useMatchResult.ts
+++ b/src/features/match/hooks/useMatchResult.ts
@@ -4,11 +4,13 @@ import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
 import { getMatchResult } from '../api/matchApi';
 import type { MatchResult } from '@/shared/types/match';
 
+export const MATCH_RESULT_QUERY_KEY = ['match-result'] as const;
+
 export function useMatchResult(
   options?: Omit<UseQueryOptions<MatchResult | null>, 'queryKey' | 'queryFn'>,
 ) {
   return useQuery({
-    queryKey: ['match-result'],
+    queryKey: MATCH_RESULT_QUERY_KEY,
     queryFn: getMatchResult,
     ...options,
   });

--- a/src/features/profile/hooks/useProfile.ts
+++ b/src/features/profile/hooks/useProfile.ts
@@ -29,9 +29,11 @@ function toUserProfile(p: Profile): UserProfile {
   };
 }
 
+export const PROFILE_QUERY_KEY = ['profile'] as const;
+
 export function useProfile() {
   const { data: profile, isLoading: isProfileLoading } = useQuery({
-    queryKey: ['profile'],
+    queryKey: PROFILE_QUERY_KEY,
     queryFn: getProfile,
   });
 

--- a/src/features/survey/hooks/useSurveyForm.ts
+++ b/src/features/survey/hooks/useSurveyForm.ts
@@ -17,7 +17,9 @@ import {
 } from '../utils/options';
 import { submitSurvey } from '../api/surveyApi';
 import { generateMatch } from '@/features/match/api/matchApi';
+import { MATCH_RESULT_QUERY_KEY } from '@/features/match/hooks/useMatchResult';
 import { getProfile } from '@/features/profile/api/profileApi';
+import { PROFILE_QUERY_KEY } from '@/features/profile/hooks/useProfile';
 import type { Profile } from '@/shared/types/profile';
 
 export type { SurveyFormValues };
@@ -96,7 +98,7 @@ export function useSurveyForm(mode: 'create' | 'edit' = 'create') {
   });
 
   const { data: existingProfile } = useQuery({
-    queryKey: ['profile'],
+    queryKey: PROFILE_QUERY_KEY,
     queryFn: getProfile,
     enabled: mode === 'edit',
   });
@@ -185,7 +187,7 @@ export function useSurveyForm(mode: 'create' | 'edit' = 'create') {
       hope_activities: activities,
     });
 
-    queryClient.invalidateQueries({ queryKey: ['profile'] });
+    queryClient.invalidateQueries({ queryKey: PROFILE_QUERY_KEY });
     queryClient.removeQueries({ queryKey: ['job-postings'] });
     localStorage.removeItem('matchzoom-job-sigungu-filter');
     localStorage.removeItem('matchzoom-job-fitlevel-filter');
@@ -193,7 +195,7 @@ export function useSurveyForm(mode: 'create' | 'edit' = 'create') {
 
     try {
       await generateMatch();
-      queryClient.invalidateQueries({ queryKey: ['match-result'] });
+      queryClient.invalidateQueries({ queryKey: MATCH_RESULT_QUERY_KEY });
       setIsComplete(true);
     } catch {
       setIsMatchError(true);

--- a/src/shared/providers/query-provider.tsx
+++ b/src/shared/providers/query-provider.tsx
@@ -1,12 +1,13 @@
 'use client';
 
+import { useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { ReactNode } from 'react';
 
-const queryClient = new QueryClient();
-
 export const QueryProvider = ({ children }: { children: ReactNode }) => {
+  const [queryClient] = useState(() => new QueryClient());
+
   return (
     <QueryClientProvider client={queryClient}>
       {children}


### PR DESCRIPTION
## 개요

대시보드 진입 시 서버에서 이미 조회한 `profile` / `matchResult` 데이터를 클라이언트 컴포넌트가 마운트되면서 다시 API를 호출하는 중복 fetch 문제를 제거했습니다.
아울러 모듈 레벨 `QueryClient` 싱글턴으로 인한 요청 간 데이터 오염 가능성도 함께 수정했습니다.

## 왜 이 문제가 발생했는가

| 파일 | 기존 문제 |
|------|-----------|
| `query-provider.tsx` | `QueryClient`를 모듈 최상단에서 1회만 생성 → SSR 환경에서 여러 유저 요청이 동일 인스턴스 공유 |
| `page.tsx` | 서버에서 profile `id` 존재 여부만 확인 → 클라이언트 훅이 다시 전체 데이터 fetch |
| `useJobPostings.ts` | `useSuspenseQuery` 사용 시 HydrationBoundary 구조 변경 후 처리 복잡도 증가 |

## 주요 변경 사항

### `query-provider.tsx` — QueryClient 싱글턴 제거
- `const queryClient = new QueryClient()` → `useState(() => new QueryClient())`
- 컴포넌트 마운트 시마다 독립 인스턴스 생성 → 요청 간 데이터 오염 방지

### `page.tsx` — HydrationBoundary 도입
- 서버에서 `profile` + `matchResult`를 `Promise.all`로 동시 조회
- `queryClient.setQueryData()`로 캐시에 미리 주입 후 `dehydrate()` → `HydrationBoundary`로 클라이언트 전달
- 클라이언트 훅은 캐시를 그대로 사용 → 추가 API 호출 없음
- 테스트 유저도 동일 구조로 통일 (`TEST_PROFILE`, `TEST_MATCH` 주입)

### `useJobPostings.ts` — useSuspenseQuery → useQuery
- job-postings는 서버 프리페치 대상이 아니므로 `useQuery`로 교체

### `DashboardView.tsx` — undefined 방어 처리
- `useQuery` 전환으로 `data`가 `undefined`일 수 있으므로 `postings ?? []` 추가

### `layout.tsx` — suppressHydrationWarning 추가
- 브라우저 확장 프로그램이 `<body>` 속성을 변경할 때 발생하는 Hydration 불일치 경고 억제

## 데이터 흐름 비교

**이전**
```
서버(id만 확인) → 클라이언트 mount → useProfile fetch → useMatchResult fetch
```

**이후**
```
서버(profile + matchResult 조회 → QueryClient 주입) → 클라이언트 hydrate → 추가 fetch 없음
```

Closes #145