### PR TITLE
fix: 대시보드 isPending 스켈레톤 처리 추가 #147

### DIFF
--- a/src/features/dashboard/hooks/useDashboard.ts
+++ b/src/features/dashboard/hooks/useDashboard.ts
@@ -11,12 +11,12 @@ import {
 } from '@/features/match/utils/convert';
 
 export function useDashboard() {
-  const { data: profile } = useQuery({
+  const { data: profile, isPending: isProfilePending } = useQuery({
     queryKey: PROFILE_QUERY_KEY,
     queryFn: getProfile,
   });
 
-  const { data: matchResult } = useQuery({
+  const { data: matchResult, isPending: isMatchPending } = useQuery({
     queryKey: MATCH_RESULT_QUERY_KEY,
     queryFn: getMatchResult,
   });
@@ -26,6 +26,7 @@ export function useDashboard() {
     : [];
 
   return {
+    isPending: isProfilePending || isMatchPending,
     userName: profile?.name ?? '',
     personalityAxes: matchResult
       ? toPersonalityAxes(matchResult.radar_chart)

--- a/src/features/dashboard/ui/DashboardSkeleton.tsx
+++ b/src/features/dashboard/ui/DashboardSkeleton.tsx
@@ -1,19 +1,31 @@
+'use client';
+
+import { AIResultCard } from '@/shared/ui/AIResultCard';
+import { JobListSection } from './JobListSection';
+
 export function DashboardSkeleton() {
   return (
-    <div className="animate-pulse py-10 md:py-16">
+    <div className="py-10 md:py-16">
       <div className="mx-auto flex max-w-[1200px] flex-col gap-[60px] px-4 md:px-5 lg:px-6">
-        {/* AIResultCard 스켈레톤 */}
-        <div className="h-[360px] rounded-2xl bg-gray-100" />
+        <section aria-labelledby="result-summary-heading">
+          <h2 id="result-summary-heading" className="sr-only">
+            검사 결과 요약
+          </h2>
+          <AIResultCard isLoading userName="" axes={[]} summary="" jobs={[]} />
+        </section>
 
-        {/* JobListSection 스켈레톤 */}
-        <div className="flex flex-col gap-4">
-          <div className="h-10 w-48 rounded-lg bg-gray-100" />
-          <div className="flex flex-col gap-3">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <div key={i} className="h-28 rounded-xl bg-gray-100" />
-            ))}
-          </div>
-        </div>
+        <section aria-labelledby="job-postings-heading">
+          <h2 id="job-postings-heading" className="sr-only">
+            맞춤 채용공고
+          </h2>
+          <JobListSection
+            isLoading
+            isLoadingUser
+            userName=""
+            postings={[]}
+            onBookmarkToggle={() => {}}
+          />
+        </section>
       </div>
     </div>
   );

--- a/src/features/dashboard/ui/DashboardView.tsx
+++ b/src/features/dashboard/ui/DashboardView.tsx
@@ -12,16 +12,14 @@ import { ConfirmModal } from '@/shared/ui/ConfirmModal';
 
 export function DashboardView() {
   const {
-    isPending,
+    isPending: isDashboardPending,
     userName,
     personalityAxes,
     personalitySummary,
     matchedJobs,
     profileProvinces,
   } = useDashboard();
-
-  if (isPending) return <DashboardSkeleton />;
-  const { data: postings } = useJobPostings();
+  const { data: postings, isPending: isPostingsPending } = useJobPostings();
   const {
     availableSigungu,
     selectedSigungu,
@@ -39,6 +37,8 @@ export function DashboardView() {
     loginModalOpen,
     closeLoginModal,
   } = useBookmarkToggle();
+
+  if (isDashboardPending || isPostingsPending) return <DashboardSkeleton />;
 
   return (
     <div className="py-10 md:py-16">

--- a/src/features/dashboard/ui/DashboardView.tsx
+++ b/src/features/dashboard/ui/DashboardView.tsx
@@ -6,7 +6,6 @@ import { useJobRegionFilter } from '../hooks/useJobRegionFilter';
 import { useJobFitFilter } from '../hooks/useJobFitFilter';
 import { useBookmarkToggle } from '../hooks/useBookmarkToggle';
 import { JobListSection } from './JobListSection';
-import { DashboardSkeleton } from './DashboardSkeleton';
 import { AIResultCard } from '@/shared/ui/AIResultCard';
 import { ConfirmModal } from '@/shared/ui/ConfirmModal';
 
@@ -38,8 +37,6 @@ export function DashboardView() {
     closeLoginModal,
   } = useBookmarkToggle();
 
-  if (isDashboardPending || isPostingsPending) return <DashboardSkeleton />;
-
   return (
     <div className="py-10 md:py-16">
       <div className="mx-auto flex max-w-[1200px] flex-col gap-[60px] px-4 md:px-5 lg:px-6">
@@ -48,6 +45,7 @@ export function DashboardView() {
             검사 결과 요약
           </h2>
           <AIResultCard
+            isLoading={isDashboardPending}
             userName={userName}
             axes={personalityAxes}
             summary={personalitySummary}
@@ -60,6 +58,8 @@ export function DashboardView() {
             맞춤 채용공고
           </h2>
           <JobListSection
+            isLoading={isPostingsPending}
+            isLoadingUser={isDashboardPending}
             userName={userName}
             postings={filteredPostings}
             onBookmarkToggle={handleBookmarkToggle}

--- a/src/features/dashboard/ui/DashboardView.tsx
+++ b/src/features/dashboard/ui/DashboardView.tsx
@@ -6,17 +6,21 @@ import { useJobRegionFilter } from '../hooks/useJobRegionFilter';
 import { useJobFitFilter } from '../hooks/useJobFitFilter';
 import { useBookmarkToggle } from '../hooks/useBookmarkToggle';
 import { JobListSection } from './JobListSection';
+import { DashboardSkeleton } from './DashboardSkeleton';
 import { AIResultCard } from '@/shared/ui/AIResultCard';
 import { ConfirmModal } from '@/shared/ui/ConfirmModal';
 
 export function DashboardView() {
   const {
+    isPending,
     userName,
     personalityAxes,
     personalitySummary,
     matchedJobs,
     profileProvinces,
   } = useDashboard();
+
+  if (isPending) return <DashboardSkeleton />;
   const { data: postings } = useJobPostings();
   const {
     availableSigungu,


### PR DESCRIPTION
## 개요
`Suspense` 제거 후 빠진 대시보드 스켈레톤을 `isPending`으로 복원.

## 주요 변경 사항
- `useDashboard`: `profile`·`matchResult` 두 쿼리의 `isPending`을 OR로 합쳐 반환
- `DashboardView`: `isPending` true이면 `<DashboardSkeleton />` 즉시 렌더

Closes #147