### PR TITLE
🚩fix: 북마크 URL 충돌 수정 및 대시보드 SSR 프리페치 #151

### DIFF
--- a/src/app/api/job-postings/route.ts
+++ b/src/app/api/job-postings/route.ts
@@ -1,77 +1,12 @@
-import { XMLParser } from 'fast-xml-parser';
-
 import { createAuthorizedRoute } from '@/shared/api/createAuthorizedRoute';
 import { supabaseFetch } from '@/shared/api/supabaseFetch';
-import type { FitLevel } from '@/shared/types/job';
+import {
+  dedupeItems,
+  parseJobItems,
+  rankPostings,
+  type ProfileRow,
+} from '@/features/dashboard/utils/jobPostings';
 import { TEST_USER_ID, TEST_PROFILE } from '@/shared/utils/testUser';
-
-type RawItem = {
-  busplaName?: string;
-  compAddr?: string;
-  empType?: string;
-  regagnName?: string;
-  envBothHands?: string;
-  envEyesight?: string;
-  envHandWork?: string;
-  envLiftPower?: string;
-  envLstnTalk?: string;
-  envStndWalk?: string;
-  jobNm?: string;
-  reqCareer?: string;
-  reqEduc?: string;
-  rno: number;
-  salary?: string;
-  salaryType?: string;
-  termDate?: string;
-};
-
-type ProfileRow = {
-  mobility: string;
-  hand_usage: string;
-  stamina: string;
-  communication: string;
-  region_primary: string;
-};
-
-const ENV_KEYS: (keyof RawItem)[] = [
-  'envBothHands',
-  'envEyesight',
-  'envHandWork',
-  'envLiftPower',
-  'envLstnTalk',
-  'envStndWalk',
-];
-
-const parser = new XMLParser({ ignoreAttributes: false });
-
-function computeScore(item: RawItem, profile: ProfileRow): number {
-  let score = 0;
-
-  if (item.envStndWalk?.includes('어려움')) {
-    score += profile.mobility !== '자유로움' ? 2 : 1;
-  }
-  if (item.envLstnTalk?.includes('어려움')) {
-    score += profile.communication !== '일상 대화 가능' ? 2 : 1;
-  }
-  if (item.envHandWork && profile.hand_usage !== '손 사용 어려움') {
-    score += 1;
-  }
-  if (
-    item.envBothHands?.includes('양손') &&
-    profile.hand_usage === '세밀한 작업 가능'
-  ) {
-    score += 1;
-  }
-  if (item.envLiftPower?.includes('이내')) {
-    score += profile.stamina !== '4시간 이상 활동 가능' ? 2 : 1;
-  }
-
-  return score;
-}
-
-function toFitLevel(score: number): FitLevel {
-  return score >= 3 ? '잘 맞아요' : '도전해볼 수 있어요';
-}
 
 export const GET = createAuthorizedRoute(async ({ userId }) => {
   const baseUrl = process.env.JOB_API_BASE_URL;
@@ -103,89 +38,7 @@ export const GET = createAuthorizedRoute(async ({ userId }) => {
 
   const profile = profileRows[0];
   const bookmarkedUrls = new Set(bookmarkRows.map((r) => r.posting_url));
-  const parsed = parser.parse(jobXml);
-  const raw: RawItem | RawItem[] = parsed?.response?.body?.items?.item ?? [];
-  const allItems = Array.isArray(raw) ? raw : [raw];
+  const unique = dedupeItems(parseJobItems(jobXml));
 
-  // 중복 제거
-  const seen = new Set<string>();
-  const unique = allItems.filter((item) => {
-    const key = `${item.busplaName}|${item.jobNm}|${item.termDate}|${item.empType}|${item.salary}`;
-    if (seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
-
-  // 프로필 없으면 그대로 20개 반환
-  if (!profile) {
-    return unique
-      .slice(0, 20)
-      .map((item) => toPosting(item, undefined, undefined, bookmarkedUrls));
-  }
-
-  const REGION_ABBR: Record<string, string> = {
-    경기: '경기도',
-    강원: '강원특별자치도',
-    충북: '충청북도',
-    충남: '충청남도',
-    전북: '전북특별자치도',
-    전남: '전라남도',
-    경북: '경상북도',
-    경남: '경상남도',
-    제주: '제주특별자치도',
-  };
-
-  function agencyCity(regagnName: string): string | null {
-    const m = regagnName.match(/한국장애인고용공단\s([가-힣]{2})/);
-    if (!m) return null;
-    const abbr = m[1];
-    return REGION_ABBR[abbr] ?? abbr;
-  }
-
-  const primaryCity = profile.region_primary.split(' ')[0];
-
-  const matchesRegion = (regagnName: string | undefined): boolean => {
-    if (!regagnName) return false;
-    const city = agencyCity(regagnName);
-    if (!city) return false;
-    return primaryCity.startsWith(city);
-  };
-
-  const pool = unique.filter((item) => matchesRegion(item.regagnName));
-
-  // 점수 내림차순 정렬 후 상위 20개
-  const sorted = pool
-    .map((item) => ({ item, score: computeScore(item, profile) }))
-    .sort((a, b) => b.score - a.score)
-    .slice(0, 20);
-
-  return sorted.map(({ item, score }) =>
-    toPosting(item, profile, score, bookmarkedUrls),
-  );
+  return rankPostings(unique, profile, bookmarkedUrls);
 });
-
-function toPosting(
-  item: RawItem,
-  profile: ProfileRow | undefined,
-  score: number | undefined,
-  bookmarkedUrls: Set<string>,
-) {
-  const detailUrl = `https://www.work24.go.kr/wk/a/b/1700/themeEmpInfoSrchList.do?thmaHrplCd=F00036&resultCnt=10&searchMode=Y&currentPageNo=1&pageIndex=1&sortField=DATE&sortOrderBy=DESC&srcKeyword=${encodeURIComponent(item.busplaName ?? '')}`;
-  return {
-    id: item.rno,
-    companyName: item.busplaName ?? '',
-    title: item.jobNm ?? '',
-    location: item.compAddr ?? '',
-    salary: item.salary
-      ? `${Number(item.salary.replace(/,/g, '')).toLocaleString('ko-KR')}원 (${item.salaryType})`
-      : '협의',
-    deadline: item.termDate?.split('~')[1] ?? '',
-    empType: item.empType ?? '',
-    reqCareer: item.reqCareer ?? '',
-    reqEduc: item.reqEduc ?? '',
-    envConditions: ENV_KEYS.map((k) => item[k] as string).filter(Boolean),
-    fitLevel: profile && score !== undefined ? toFitLevel(score) : undefined,
-    detailUrl,
-    bookmarked: bookmarkedUrls.has(detailUrl),
-  };
-}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,12 +6,24 @@ import {
 import { supabaseFetch } from '@/shared/api/supabaseFetch';
 import { getServerSession } from '@/shared/utils/serverSession';
 import { DashboardView } from '@/features/dashboard';
+import {
+  dedupeItems,
+  parseJobItems,
+  rankPostings,
+  type ProfileRow,
+} from '@/features/dashboard/utils/jobPostings';
 import { LandingPage } from '@/features/landing';
+import { JOB_POSTINGS_QUERY_KEY } from '@/features/dashboard/hooks/useJobPostings';
 import { PROFILE_QUERY_KEY } from '@/features/profile/hooks/useProfile';
 import { MATCH_RESULT_QUERY_KEY } from '@/features/match/hooks/useMatchResult';
-import { TEST_PROFILE, TEST_MATCH } from '@/shared/utils/testUser';
+import {
+  TEST_USER_ID,
+  TEST_PROFILE,
+  TEST_MATCH,
+} from '@/shared/utils/testUser';
 import type { Profile } from '@/shared/types/profile';
 import type { MatchResult } from '@/shared/types/match';
+import type { JobPosting } from '@/shared/types/job';
 
 async function getDashboardData(userId: string) {
   const [profileRows, matchRows] = await Promise.all([
@@ -23,6 +35,31 @@ async function getDashboardData(userId: string) {
   return { profile: profileRows[0] ?? null, matchResult: matchRows[0] ?? null };
 }
 
+async function getJobPostingsData(
+  userId: string,
+  profile: ProfileRow | undefined,
+): Promise<JobPosting[]> {
+  const baseUrl = process.env.JOB_API_BASE_URL;
+  const serviceKey = process.env.JOB_API_KEY;
+  if (!baseUrl || !serviceKey) return [];
+
+  const [bookmarkRows, jobXml] = await Promise.all([
+    userId === TEST_USER_ID
+      ? Promise.resolve([])
+      : supabaseFetch<{ posting_url: string }[]>(
+          `/rest/v1/bookmarks?user_id=eq.${userId}&select=posting_url`,
+        ),
+    fetch(
+      `${baseUrl}?serviceKey=${encodeURIComponent(serviceKey)}&numOfRows=100&pageNo=1`,
+      { next: { revalidate: 300 } },
+    ).then((r) => r.text()),
+  ]);
+
+  const bookmarkedUrls = new Set(bookmarkRows.map((r) => r.posting_url));
+  const unique = dedupeItems(parseJobItems(jobXml));
+  return rankPostings(unique, profile, bookmarkedUrls);
+}
+
 export default async function Home() {
   const session = await getServerSession();
 
@@ -32,9 +69,19 @@ export default async function Home() {
       : await getDashboardData(session.userId);
 
     if (profile) {
+      const profileRow: ProfileRow = {
+        mobility: profile.mobility,
+        hand_usage: profile.hand_usage,
+        stamina: profile.stamina,
+        communication: profile.communication,
+        region_primary: profile.region_primary,
+      };
+      const jobPostings = await getJobPostingsData(session.userId, profileRow);
+
       const queryClient = new QueryClient();
       queryClient.setQueryData(PROFILE_QUERY_KEY, profile);
       queryClient.setQueryData(MATCH_RESULT_QUERY_KEY, matchResult);
+      queryClient.setQueryData(JOB_POSTINGS_QUERY_KEY, jobPostings);
 
       return (
         <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/features/dashboard/hooks/useBookmarkToggle.ts
+++ b/src/features/dashboard/hooks/useBookmarkToggle.ts
@@ -5,6 +5,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import type { JobPosting } from '@/shared/types/job';
 import { addBookmark, removeBookmark } from '../api/bookmarkApi';
+import { JOB_POSTINGS_QUERY_KEY } from './useJobPostings';
 import { useCurrentUser } from '@/shared/hooks/useCurrentUser';
 
 export function useBookmarkToggle() {
@@ -25,14 +26,18 @@ export function useBookmarkToggle() {
           ),
 
     onMutate: async (job) => {
-      await queryClient.cancelQueries({ queryKey: ['job-postings'] });
+      await queryClient.cancelQueries({ queryKey: JOB_POSTINGS_QUERY_KEY });
 
-      const previous = queryClient.getQueryData<JobPosting[]>(['job-postings']);
+      const previous = queryClient.getQueryData<JobPosting[]>(
+        JOB_POSTINGS_QUERY_KEY,
+      );
 
-      queryClient.setQueryData<JobPosting[]>(['job-postings'], (old = []) =>
-        old.map((p) =>
-          p.id === job.id ? { ...p, bookmarked: !p.bookmarked } : p,
-        ),
+      queryClient.setQueryData<JobPosting[]>(
+        JOB_POSTINGS_QUERY_KEY,
+        (old = []) =>
+          old.map((p) =>
+            p.id === job.id ? { ...p, bookmarked: !p.bookmarked } : p,
+          ),
       );
 
       return { previous };
@@ -40,7 +45,7 @@ export function useBookmarkToggle() {
 
     onError: (_err, _job, ctx) => {
       if (ctx?.previous) {
-        queryClient.setQueryData(['job-postings'], ctx.previous);
+        queryClient.setQueryData(JOB_POSTINGS_QUERY_KEY, ctx.previous);
       }
     },
   });

--- a/src/features/dashboard/hooks/useJobPostings.ts
+++ b/src/features/dashboard/hooks/useJobPostings.ts
@@ -3,9 +3,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { getJobPostings } from '../api/jobPostingsApi';
 
+export const JOB_POSTINGS_QUERY_KEY = ['job-postings'] as const;
+
 export function useJobPostings() {
   return useQuery({
-    queryKey: ['job-postings'],
+    queryKey: JOB_POSTINGS_QUERY_KEY,
     queryFn: ({ signal }) => getJobPostings(signal),
     staleTime: 5 * 60 * 1000,
   });

--- a/src/features/dashboard/utils/jobPostings.ts
+++ b/src/features/dashboard/utils/jobPostings.ts
@@ -1,0 +1,172 @@
+import { XMLParser } from 'fast-xml-parser';
+
+import type { FitLevel, JobPosting } from '@/shared/types/job';
+
+export type RawItem = {
+  busplaName?: string;
+  compAddr?: string;
+  empType?: string;
+  regagnName?: string;
+  envBothHands?: string;
+  envEyesight?: string;
+  envHandWork?: string;
+  envLiftPower?: string;
+  envLstnTalk?: string;
+  envStndWalk?: string;
+  jobNm?: string;
+  reqCareer?: string;
+  reqEduc?: string;
+  rno: number;
+  salary?: string;
+  salaryType?: string;
+  termDate?: string;
+};
+
+export type ProfileRow = {
+  mobility: string;
+  hand_usage: string;
+  stamina: string;
+  communication: string;
+  region_primary: string;
+};
+
+const LIMIT = 20;
+
+const ENV_KEYS: (keyof RawItem)[] = [
+  'envBothHands',
+  'envEyesight',
+  'envHandWork',
+  'envLiftPower',
+  'envLstnTalk',
+  'envStndWalk',
+];
+
+const REGION_ABBR: Record<string, string> = {
+  경기: '경기도',
+  강원: '강원특별자치도',
+  충북: '충청북도',
+  충남: '충청남도',
+  전북: '전북특별자치도',
+  전남: '전라남도',
+  경북: '경상북도',
+  경남: '경상남도',
+  제주: '제주특별자치도',
+};
+
+const parser = new XMLParser({ ignoreAttributes: false });
+
+function postingHash(item: RawItem): string {
+  const key = `${item.busplaName}|${item.jobNm}|${item.termDate}|${item.empType}|${item.salary}`;
+  let h = 0;
+  for (let i = 0; i < key.length; i++) {
+    h = (h * 31 + key.charCodeAt(i)) | 0;
+  }
+  return (h >>> 0).toString(36);
+}
+
+export function parseJobItems(xml: string): RawItem[] {
+  const parsed = parser.parse(xml);
+  const raw: RawItem | RawItem[] = parsed?.response?.body?.items?.item ?? [];
+  return Array.isArray(raw) ? raw : [raw];
+}
+
+export function dedupeItems(items: RawItem[]): RawItem[] {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    const key = `${item.busplaName}|${item.jobNm}|${item.termDate}|${item.empType}|${item.salary}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function agencyCity(regagnName: string): string | null {
+  const m = regagnName.match(/한국장애인고용공단\s([가-힣]{2})/);
+  if (!m) return null;
+  return REGION_ABBR[m[1]] ?? m[1];
+}
+
+function matchesProfileRegion(
+  regagnName: string | undefined,
+  profile: ProfileRow,
+): boolean {
+  if (!regagnName) return false;
+  const city = agencyCity(regagnName);
+  if (!city) return false;
+  const primaryCity = profile.region_primary.split(' ')[0];
+  return primaryCity.startsWith(city);
+}
+
+function computeScore(item: RawItem, profile: ProfileRow): number {
+  let score = 0;
+
+  if (item.envStndWalk?.includes('어려움')) {
+    score += profile.mobility !== '자유로움' ? 2 : 1;
+  }
+  if (item.envLstnTalk?.includes('어려움')) {
+    score += profile.communication !== '일상 대화 가능' ? 2 : 1;
+  }
+  if (item.envHandWork && profile.hand_usage !== '손 사용 어려움') {
+    score += 1;
+  }
+  if (
+    item.envBothHands?.includes('양손') &&
+    profile.hand_usage === '세밀한 작업 가능'
+  ) {
+    score += 1;
+  }
+  if (item.envLiftPower?.includes('이내')) {
+    score += profile.stamina !== '4시간 이상 활동 가능' ? 2 : 1;
+  }
+
+  return score;
+}
+
+function toFitLevel(score: number): FitLevel {
+  return score >= 3 ? '잘 맞아요' : '도전해볼 수 있어요';
+}
+
+function toPosting(
+  item: RawItem,
+  profile: ProfileRow | undefined,
+  score: number | undefined,
+  bookmarkedUrls: Set<string>,
+): JobPosting {
+  const detailUrl = `https://www.work24.go.kr/wk/a/b/1700/themeEmpInfoSrchList.do?thmaHrplCd=F00036&resultCnt=10&searchMode=Y&currentPageNo=1&pageIndex=1&sortField=DATE&sortOrderBy=DESC&srcKeyword=${encodeURIComponent(item.busplaName ?? '')}#${postingHash(item)}`;
+  return {
+    id: item.rno,
+    companyName: item.busplaName ?? '',
+    title: item.jobNm ?? '',
+    location: item.compAddr ?? '',
+    salary: item.salary
+      ? `${Number(item.salary.replace(/,/g, '')).toLocaleString('ko-KR')}원 (${item.salaryType})`
+      : '협의',
+    deadline: item.termDate?.split('~')[1] ?? '',
+    empType: item.empType ?? '',
+    reqCareer: item.reqCareer ?? '',
+    reqEduc: item.reqEduc ?? '',
+    envConditions: ENV_KEYS.map((k) => item[k] as string).filter(Boolean),
+    fitLevel: profile && score !== undefined ? toFitLevel(score) : undefined,
+    detailUrl,
+    bookmarked: bookmarkedUrls.has(detailUrl),
+  };
+}
+
+export function rankPostings(
+  items: RawItem[],
+  profile: ProfileRow | undefined,
+  bookmarkedUrls: Set<string>,
+): JobPosting[] {
+  if (!profile) {
+    return items
+      .slice(0, LIMIT)
+      .map((item) => toPosting(item, undefined, undefined, bookmarkedUrls));
+  }
+
+  return items
+    .filter((item) => matchesProfileRegion(item.regagnName, profile))
+    .map((item) => ({ item, score: computeScore(item, profile) }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, LIMIT)
+    .map(({ item, score }) => toPosting(item, profile, score, bookmarkedUrls));
+}

--- a/src/features/profile/hooks/useBookmarkRemove.ts
+++ b/src/features/profile/hooks/useBookmarkRemove.ts
@@ -5,6 +5,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import type { Bookmark } from '@/shared/types/bookmark';
 import { removeBookmark } from '../api/bookmarksApi';
+import { BOOKMARKS_QUERY_KEY } from './useScrapedJobs';
 import { useCurrentUser } from '@/shared/hooks/useCurrentUser';
 
 export function useBookmarkRemove() {
@@ -16,11 +17,12 @@ export function useBookmarkRemove() {
     mutationFn: (postingUrl: string) => removeBookmark(postingUrl),
 
     onMutate: async (postingUrl) => {
-      await queryClient.cancelQueries({ queryKey: ['bookmarks'] });
+      await queryClient.cancelQueries({ queryKey: BOOKMARKS_QUERY_KEY });
 
-      const previous = queryClient.getQueryData<Bookmark[]>(['bookmarks']);
+      const previous =
+        queryClient.getQueryData<Bookmark[]>(BOOKMARKS_QUERY_KEY);
 
-      queryClient.setQueryData<Bookmark[]>(['bookmarks'], (old = []) =>
+      queryClient.setQueryData<Bookmark[]>(BOOKMARKS_QUERY_KEY, (old = []) =>
         old.filter((b) => b.postingUrl !== postingUrl),
       );
 
@@ -29,7 +31,7 @@ export function useBookmarkRemove() {
 
     onError: (_err, _url, ctx) => {
       if (ctx?.previous) {
-        queryClient.setQueryData(['bookmarks'], ctx.previous);
+        queryClient.setQueryData(BOOKMARKS_QUERY_KEY, ctx.previous);
       }
     },
   });

--- a/src/features/profile/hooks/useScrapedJobs.ts
+++ b/src/features/profile/hooks/useScrapedJobs.ts
@@ -4,9 +4,11 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getBookmarks } from '../api/bookmarksApi';
 
+export const BOOKMARKS_QUERY_KEY = ['bookmarks'] as const;
+
 export function useScrapedJobs() {
   return useQuery({
-    queryKey: ['bookmarks'],
+    queryKey: BOOKMARKS_QUERY_KEY,
     queryFn: getBookmarks,
   });
 }

--- a/src/features/survey/hooks/useSurveyForm.ts
+++ b/src/features/survey/hooks/useSurveyForm.ts
@@ -16,6 +16,7 @@ import {
   HOPE_ACTIVITIES_VALUES,
 } from '../utils/options';
 import { submitSurvey } from '../api/surveyApi';
+import { JOB_POSTINGS_QUERY_KEY } from '@/features/dashboard/hooks/useJobPostings';
 import { generateMatch } from '@/features/match/api/matchApi';
 import { MATCH_RESULT_QUERY_KEY } from '@/features/match/hooks/useMatchResult';
 import { getProfile } from '@/features/profile/api/profileApi';
@@ -188,7 +189,7 @@ export function useSurveyForm(mode: 'create' | 'edit' = 'create') {
     });
 
     queryClient.invalidateQueries({ queryKey: PROFILE_QUERY_KEY });
-    queryClient.removeQueries({ queryKey: ['job-postings'] });
+    queryClient.removeQueries({ queryKey: JOB_POSTINGS_QUERY_KEY });
     localStorage.removeItem('matchzoom-job-sigungu-filter');
     localStorage.removeItem('matchzoom-job-fitlevel-filter');
     setIsMatching(true);


### PR DESCRIPTION
## 개요
공고 URL이 회사명만으로 생성돼 같은 회사 다른 공고 북마크가 충돌하던 문제를 해결하고, 대시보드 초기 렌더를 SSR 프리페치로 개선했습니다. 겸사겸사 job-postings 로직을 feature 유틸로 재배치하고 쿼리키를 상수화했습니다.

## 주요 변경 사항

### fix — 북마크 URL 충돌
- `toPosting`의 `detailUrl` 끝에 공고 내용 기반 해시(`#hash`) 추가 → 같은 회사의 다른 공고도 유일 URL 확보
- fragment는 서버로 전송되지 않아 work24 검색 동작 영향 없음

### refactor — job-postings 로직 feature 레벨로 이동
- `src/app/api/job-postings/route.ts`의 필터링/점수/변환/정렬 로직을 `src/features/dashboard/utils/jobPostings.ts`로 이동
- 공개 API: `parseJobItems`, `dedupeItems`, `rankPostings`
- route.ts는 I/O 오케스트레이션만 담당

### perf — 대시보드 SSR 프리페치
- `src/app/page.tsx` Server Component에서 외부 공고 API + bookmarks 병렬 조회 → `rankPostings` 수행 → `JOB_POSTINGS_QUERY_KEY`로 hydrate
- 초기 스켈레톤/네트워크 waterfall 감소

### chore — 쿼리키 상수화
- `JOB_POSTINGS_QUERY_KEY`, `BOOKMARKS_QUERY_KEY`를 각 훅에서 export
- 인라인 `['job-postings']`, `['bookmarks']` 사용처 모두 교체 (page.tsx, useBookmarkToggle, useBookmarkRemove, useSurveyForm)

## 스크린샷
해당 없음 (UI 변경 없음)

Closes #151