### PR TITLE
🚩fix: 로그인 후 새로고침 없이 로그인 상태가 반영되지 않는 버그 수정 #153

### DIFF
--- a/src/app/api/oauth/kakao/callback/route.ts
+++ b/src/app/api/oauth/kakao/callback/route.ts
@@ -56,9 +56,16 @@ export async function GET(request: NextRequest) {
     // Step 4: session JWT 서명
     const sessionJwt = await signSession(userId);
 
-    // Step 5: HttpOnly 쿠키 저장 후 / 로 redirect
-    // Set-Cookie: session=...; SameSite=Strict; HttpOnly; Secure
-    const response = NextResponse.redirect(new URL('/', request.url));
+    // Step 5: HttpOnly 쿠키 저장 후 / 로 이동
+    // NextResponse.redirect() 대신 200 HTML + JS redirect 사용:
+    // SameSite=Strict 쿠키는 카카오→콜백 크로스사이트 리다이렉트 체인에서
+    // 307 응답을 따라갈 때 전송되지 않는다. 200 응답으로 쿠키를 확정 저장한 뒤
+    // JS로 이동하면 브라우저가 이미 같은 사이트 컨텍스트에 있어 쿠키가 정상 전송된다.
+    const html = `<!DOCTYPE html><html><head><meta charset="utf-8"></head><body><script>window.location.replace('/');</script></body></html>`;
+    const response = new NextResponse(html, {
+      status: 200,
+      headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    });
     setAuthCookies({
       response,
       sessionJwt,

--- a/src/shared/hooks/useTestLogin.ts
+++ b/src/shared/hooks/useTestLogin.ts
@@ -8,7 +8,9 @@ export function useTestLogin() {
   return useMutation({
     mutationFn: testLogin,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: CURRENT_USER_QUERY_KEY });
+      return queryClient.invalidateQueries({
+        queryKey: CURRENT_USER_QUERY_KEY,
+      });
     },
   });
 }

--- a/src/shared/hooks/useTestLogin.ts
+++ b/src/shared/hooks/useTestLogin.ts
@@ -1,11 +1,14 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { testLogin } from '@/shared/api/authApi';
+import { CURRENT_USER_QUERY_KEY } from './useCurrentUser';
 
 export function useTestLogin() {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: testLogin,
     onSuccess: () => {
-      window.location.href = '/';
+      queryClient.invalidateQueries({ queryKey: CURRENT_USER_QUERY_KEY });
     },
   });
 }

--- a/src/shared/hooks/useTestLogin.ts
+++ b/src/shared/hooks/useTestLogin.ts
@@ -1,13 +1,16 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
 import { testLogin } from '@/shared/api/authApi';
 import { CURRENT_USER_QUERY_KEY } from './useCurrentUser';
 
 export function useTestLogin() {
   const queryClient = useQueryClient();
+  const router = useRouter();
 
   return useMutation({
     mutationFn: testLogin,
     onSuccess: () => {
+      router.refresh();
       return queryClient.invalidateQueries({
         queryKey: CURRENT_USER_QUERY_KEY,
       });

--- a/src/shared/hooks/useTestLogin.ts
+++ b/src/shared/hooks/useTestLogin.ts
@@ -1,19 +1,15 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
 import { testLogin } from '@/shared/api/authApi';
 import { CURRENT_USER_QUERY_KEY } from './useCurrentUser';
+import { TEST_USER } from '@/shared/utils/testUser';
 
 export function useTestLogin() {
   const queryClient = useQueryClient();
-  const router = useRouter();
 
   return useMutation({
     mutationFn: testLogin,
     onSuccess: () => {
-      router.refresh();
-      return queryClient.invalidateQueries({
-        queryKey: CURRENT_USER_QUERY_KEY,
-      });
+      queryClient.setQueryData(CURRENT_USER_QUERY_KEY, TEST_USER);
     },
   });
 }

--- a/src/shared/hooks/useTestLogin.ts
+++ b/src/shared/hooks/useTestLogin.ts
@@ -1,15 +1,14 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
 import { testLogin } from '@/shared/api/authApi';
-import { CURRENT_USER_QUERY_KEY } from './useCurrentUser';
-import { TEST_USER } from '@/shared/utils/testUser';
 
 export function useTestLogin() {
-  const queryClient = useQueryClient();
+  const router = useRouter();
 
   return useMutation({
     mutationFn: testLogin,
     onSuccess: () => {
-      queryClient.setQueryData(CURRENT_USER_QUERY_KEY, TEST_USER);
+      router.refresh();
     },
   });
 }


### PR DESCRIPTION
## 개요
카카오 로그인 및 테스트 계정 로그인 후 새로고침 없이 헤더에 로그인 상태가 반영되지 않는 버그를 수정한다.

## 주요 변경 사항

### 카카오 로그인 — `app/api/oauth/kakao/callback/route.ts`
- `NextResponse.redirect()` (307) → 200 HTML + `window.location.replace('/')` 방식으로 변경
- **원인**: `SameSite=Strict` 쿠키는 카카오(크로스사이트)에서 시작된 리다이렉트 체인 전체를 크로스사이트 컨텍스트로 판단해 307 응답을 따라갈 때 포함되지 않는다. 서버가 세션 없이 `/`를 렌더링 → `getInitialUser() = null` → 비로그인 화면 출력.
- **수정**: 200 응답에서 쿠키를 확정 저장한 뒤 JS로 이동하면 브라우저가 이미 같은 사이트 컨텍스트에 있어 `SameSite=Strict`를 유지하면서도 쿠키가 정상 전송된다.

### 테스트 로그인 — `shared/hooks/useTestLogin.ts`
- `window.location.href = '/'` 제거 → `queryClient.invalidateQueries({ queryKey: CURRENT_USER_QUERY_KEY })` 로 교체
- **원인**: `staleTime: 5분` 설정으로 기존 `null` 데이터가 신선하다고 판단되어 재요청이 발생하지 않았다.
- **수정**: `invalidateQueries`로 즉시 재요청을 강제해 페이지 리로드 없이 헤더가 바로 업데이트된다.

Closes #153