### PR TITLE
chore: ui 개선 #159

### DIFF
--- a/src/features/dashboard/ui/JobListSection.tsx
+++ b/src/features/dashboard/ui/JobListSection.tsx
@@ -81,7 +81,10 @@ export function JobListSection({
           className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3"
         >
           {Array.from({ length: 6 }).map((_, i) => (
-            <li key={i} className="rounded-lg border border-gray-200 p-5">
+            <li
+              key={i}
+              className="min-w-0 rounded-lg border border-gray-200 p-5"
+            >
               <Skeleton className="mb-3 h-6 w-16 rounded-sm" />
               <Skeleton className="mb-2 h-5 w-3/4 rounded-sm" />
               <Skeleton className="mb-4 h-4 w-1/2 rounded-sm" />
@@ -104,7 +107,7 @@ export function JobListSection({
           aria-label="채용공고 목록"
         >
           {postings.map((job) => (
-            <li key={job.id}>
+            <li key={job.id} className="min-w-0">
               <JobCard job={job} onBookmarkToggle={onBookmarkToggle} />
             </li>
           ))}

--- a/src/shared/ui/AIResultCard/AIResultCard.tsx
+++ b/src/shared/ui/AIResultCard/AIResultCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { MatchedJob, PersonalityAxis } from '@/shared/types/job';
+import { FitBadge } from '@/shared/ui/FitBadge';
 import { PersonalityRadarChart } from '@/shared/ui/PersonalityRadarChart';
 import { Skeleton } from '@/shared/ui/Skeleton';
 
@@ -43,48 +44,43 @@ export function AIResultCard({
             {displayName}님에게 맞는 직종 TOP 3
           </h3>
           {isLoading ? (
-            <ol className="flex flex-col divide-y divide-gray-100">
+            <ol className="flex flex-col gap-3">
               {Array.from({ length: 3 }).map((_, i) => (
                 <li
                   key={i}
-                  className="flex flex-col gap-2 py-4 first:pt-0 last:pb-0"
+                  className="flex flex-col gap-2 rounded-md border border-gray-200 px-4 py-3"
                 >
-                  <div className="flex items-center justify-between gap-2">
-                    <Skeleton className="h-5 w-2/3 rounded-sm" />
-                    <Skeleton className="h-5 w-10 rounded-sm" />
-                  </div>
-                  <Skeleton className="h-1.5 w-full rounded-full" />
+                  <Skeleton className="h-5 w-16 rounded-sm" />
+                  <Skeleton className="h-9 w-full rounded-sm" />
                 </li>
               ))}
             </ol>
           ) : (
-            <ol
-              className="flex flex-col divide-y divide-gray-100"
-              aria-label="매칭 직종 목록"
-            >
+            <ol className="flex flex-col gap-3" aria-label="매칭 직종 목록">
               {jobs.map((job, index) => (
                 <li
                   key={job.id}
                   aria-label={`${index + 1}위: ${job.name}, 매칭률 ${job.matchRate}%`}
-                  className="flex flex-col gap-2 py-4 first:pt-0 last:pb-0"
+                  className="flex flex-col gap-2 rounded-md border border-gray-200 bg-white px-4 py-3"
                 >
-                  <div className="flex items-center justify-between gap-2">
-                    <span className="text-[0.9375rem] font-semibold leading-[1.5] text-gray-900">
-                      {job.name}
-                    </span>
-                    <span className="shrink-0 tabular-nums text-[0.9375rem] font-bold text-gray-900">
-                      {job.matchRate}%
-                    </span>
-                  </div>
-                  <div className="h-1.5 w-full overflow-hidden rounded-full bg-gray-100">
+                  <FitBadge level={job.fitLevel} />
+                  <div className="relative h-9 w-full overflow-hidden rounded-sm bg-gray-100">
                     <div
-                      className="h-full rounded-full bg-primary"
+                      className="absolute inset-y-0 left-0 bg-primary/20"
                       style={{ width: `${job.matchRate}%` }}
                       role="progressbar"
                       aria-valuenow={job.matchRate}
                       aria-valuemin={0}
                       aria-valuemax={100}
                     />
+                    <div className="absolute inset-0 flex items-center justify-between px-3">
+                      <span className="text-[0.875rem] font-semibold text-gray-900">
+                        {job.name}
+                      </span>
+                      <span className="tabular-nums text-[0.875rem] font-bold text-primary">
+                        {job.matchRate}%
+                      </span>
+                    </div>
                   </div>
                 </li>
               ))}

--- a/src/shared/ui/AIResultCard/AIResultCard.tsx
+++ b/src/shared/ui/AIResultCard/AIResultCard.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import type { MatchedJob, PersonalityAxis } from '@/shared/types/job';
-import { FitBadge } from '@/shared/ui/FitBadge';
+import type { PersonalityAxis } from '@/shared/types/job';
+import { MatchedJobsCard } from '@/shared/ui/MatchedJobsCard';
 import { PersonalityRadarChart } from '@/shared/ui/PersonalityRadarChart';
 import { Skeleton } from '@/shared/ui/Skeleton';
+import type { MatchedJob } from '@/shared/types/job';
 
 type AIResultCardProps = {
   userName: string;
@@ -39,54 +40,12 @@ export function AIResultCard({
         </div>
 
         {/* 우: 맞는 직종 TOP 3 */}
-        <div className="p-6">
-          <h3 className="mb-6 border-l-[3px] border-primary pl-[10px] text-[1rem] font-semibold leading-[1.5] text-gray-900">
-            {displayName}님에게 맞는 직종 TOP 3
-          </h3>
-          {isLoading ? (
-            <ol className="flex flex-col gap-3">
-              {Array.from({ length: 3 }).map((_, i) => (
-                <li
-                  key={i}
-                  className="flex flex-col gap-2 rounded-md border border-gray-200 px-4 py-3"
-                >
-                  <Skeleton className="h-5 w-16 rounded-sm" />
-                  <Skeleton className="h-9 w-full rounded-sm" />
-                </li>
-              ))}
-            </ol>
-          ) : (
-            <ol className="flex flex-col gap-3" aria-label="매칭 직종 목록">
-              {jobs.map((job, index) => (
-                <li
-                  key={job.id}
-                  aria-label={`${index + 1}위: ${job.name}, 매칭률 ${job.matchRate}%`}
-                  className="flex flex-col gap-2 rounded-md border border-gray-200 bg-white px-4 py-3"
-                >
-                  <FitBadge level={job.fitLevel} />
-                  <div className="relative h-9 w-full overflow-hidden rounded-sm bg-gray-100">
-                    <div
-                      className="absolute inset-y-0 left-0 bg-primary/20"
-                      style={{ width: `${job.matchRate}%` }}
-                      role="progressbar"
-                      aria-valuenow={job.matchRate}
-                      aria-valuemin={0}
-                      aria-valuemax={100}
-                    />
-                    <div className="absolute inset-0 flex items-center justify-between px-3">
-                      <span className="text-[0.875rem] font-semibold text-gray-900">
-                        {job.name}
-                      </span>
-                      <span className="tabular-nums text-[0.875rem] font-bold text-primary">
-                        {job.matchRate}%
-                      </span>
-                    </div>
-                  </div>
-                </li>
-              ))}
-            </ol>
-          )}
-        </div>
+        <MatchedJobsCard
+          userName={userName}
+          jobs={jobs}
+          isLoading={isLoading}
+          className="rounded-none border-0 bg-transparent"
+        />
       </div>
 
       {/* 하단: AI 성향 요약 */}

--- a/src/shared/ui/AIResultCard/AIResultCard.tsx
+++ b/src/shared/ui/AIResultCard/AIResultCard.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import type { MatchedJob, PersonalityAxis } from '@/shared/types/job';
-import { FitBadge } from '@/shared/ui/FitBadge';
 import { PersonalityRadarChart } from '@/shared/ui/PersonalityRadarChart';
 import { Skeleton } from '@/shared/ui/Skeleton';
 
@@ -44,41 +43,48 @@ export function AIResultCard({
             {displayName}님에게 맞는 직종 TOP 3
           </h3>
           {isLoading ? (
-            <ol className="flex flex-col gap-3">
+            <ol className="flex flex-col divide-y divide-gray-100">
               {Array.from({ length: 3 }).map((_, i) => (
                 <li
                   key={i}
-                  className="flex items-center gap-4 rounded-md border border-gray-200 px-4 py-3"
+                  className="flex flex-col gap-2 py-4 first:pt-0 last:pb-0"
                 >
-                  <Skeleton className="h-6 w-6 shrink-0 rounded-sm" />
-                  <Skeleton className="h-5 flex-1 rounded-sm" />
-                  <Skeleton className="h-5 w-20 rounded-sm" />
+                  <div className="flex items-center justify-between gap-2">
+                    <Skeleton className="h-5 w-2/3 rounded-sm" />
+                    <Skeleton className="h-5 w-10 rounded-sm" />
+                  </div>
+                  <Skeleton className="h-1.5 w-full rounded-full" />
                 </li>
               ))}
             </ol>
           ) : (
-            <ol className="flex flex-col gap-3" aria-label="매칭 직종 목록">
+            <ol
+              className="flex flex-col divide-y divide-gray-100"
+              aria-label="매칭 직종 목록"
+            >
               {jobs.map((job, index) => (
                 <li
                   key={job.id}
-                  className="flex items-center gap-4 rounded-md border border-gray-200 bg-white px-4 py-3"
+                  aria-label={`${index + 1}위: ${job.name}, 매칭률 ${job.matchRate}%`}
+                  className="flex flex-col gap-2 py-4 first:pt-0 last:pb-0"
                 >
-                  <span
-                    className="flex h-6 w-6 shrink-0 items-center justify-center rounded-sm bg-gray-100 text-[0.75rem] font-semibold text-gray-500 tabular-nums"
-                    aria-label={`${index + 1}위`}
-                  >
-                    {index + 1}
-                  </span>
-                  <div className="flex w-full flex-col justify-between gap-1 sm:flex-row sm:gap-0">
-                    <span className="flex-1 text-[0.9375rem] font-semibold leading-[1.5] text-gray-900">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-[0.9375rem] font-semibold leading-[1.5] text-gray-900">
                       {job.name}
                     </span>
-                    <div className="flex items-center gap-3">
-                      <FitBadge level={job.fitLevel} />
-                      <span className="tabular-nums text-[0.875rem] font-semibold text-primary">
-                        {job.matchRate}%
-                      </span>
-                    </div>
+                    <span className="shrink-0 tabular-nums text-[0.9375rem] font-bold text-gray-900">
+                      {job.matchRate}%
+                    </span>
+                  </div>
+                  <div className="h-1.5 w-full overflow-hidden rounded-full bg-gray-100">
+                    <div
+                      className="h-full rounded-full bg-primary"
+                      style={{ width: `${job.matchRate}%` }}
+                      role="progressbar"
+                      aria-valuenow={job.matchRate}
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                    />
                   </div>
                 </li>
               ))}

--- a/src/shared/ui/AIResultCard/AIResultCard.tsx
+++ b/src/shared/ui/AIResultCard/AIResultCard.tsx
@@ -69,14 +69,16 @@ export function AIResultCard({
                   >
                     {index + 1}
                   </span>
-                  <span className="flex-1 text-[0.9375rem] font-semibold leading-[1.5] text-gray-900">
-                    {job.name}
-                  </span>
-                  <div className="flex items-center gap-3">
-                    <FitBadge level={job.fitLevel} />
-                    <span className="tabular-nums text-[0.875rem] font-semibold text-primary">
-                      {job.matchRate}%
+                  <div className="flex w-full flex-col justify-between gap-1 sm:flex-row sm:gap-0">
+                    <span className="flex-1 text-[0.9375rem] font-semibold leading-[1.5] text-gray-900">
+                      {job.name}
                     </span>
+                    <div className="flex items-center gap-3">
+                      <FitBadge level={job.fitLevel} />
+                      <span className="tabular-nums text-[0.875rem] font-semibold text-primary">
+                        {job.matchRate}%
+                      </span>
+                    </div>
                   </div>
                 </li>
               ))}

--- a/src/shared/ui/JobCard/JobCard.tsx
+++ b/src/shared/ui/JobCard/JobCard.tsx
@@ -33,7 +33,7 @@ export function JobCard({ job, onBookmarkToggle }: JobCardProps) {
   return (
     <article
       aria-label={job.title}
-      className="relative flex h-full w-full flex-col rounded-lg border border-gray-200 bg-white p-5 transition-ui hover:border-primary-border"
+      className="relative flex h-full w-full min-w-0 flex-col overflow-hidden rounded-lg border border-gray-200 bg-white p-5 transition-ui hover:border-primary-border"
     >
       {job.detailUrl && (
         <a
@@ -45,7 +45,7 @@ export function JobCard({ job, onBookmarkToggle }: JobCardProps) {
         />
       )}
       <header className="flex items-start justify-between gap-3 pb-3">
-        <div className="flex flex-col gap-1.5">
+        <div className="flex min-w-0 flex-col gap-1.5">
           {job.fitLevel && (
             <FitBadge level={job.fitLevel} className="self-start" />
           )}

--- a/src/shared/ui/LoadingOverlay/LoadingOverlay.tsx
+++ b/src/shared/ui/LoadingOverlay/LoadingOverlay.tsx
@@ -21,9 +21,9 @@ export function LoadingOverlay({ message }: Props) {
       aria-live="polite"
       aria-busy="true"
     >
-      <div className="h-10 w-10 animate-spin rounded-full border-4 border-gray-200 border-t-primary" />
+      <div className="h-10 w-10 animate-spin rounded-full border-4 border-gray-300 border-t-primary" />
       {message && (
-        <p className="mt-4 text-[0.9375rem] text-gray-600">{message}</p>
+        <p className="mt-4 text-[0.9375rem] text-gray-700">{message}</p>
       )}
     </div>
   );

--- a/src/shared/ui/MatchedJobsCard/MatchedJobsCard.tsx
+++ b/src/shared/ui/MatchedJobsCard/MatchedJobsCard.tsx
@@ -24,15 +24,15 @@ export function MatchedJobsCard({ userName, jobs }: MatchedJobsCardProps) {
             >
               {index + 1}
             </span>
-            <span className="flex-1 text-[0.9375rem] font-semibold leading-[1.5] text-gray-900">
-              {job.name}
-            </span>
-            <div className="flex items-center gap-3">
-              <FitBadge level={job.fitLevel} />
-              <span className="tabular-nums text-[0.875rem] font-semibold text-primary">
-                {job.matchRate}%
+            <div className="flex min-w-0 flex-1 flex-col gap-1">
+              <FitBadge level={job.fitLevel} className="self-start" />
+              <span className="text-[0.9375rem] font-semibold leading-[1.5] text-gray-900">
+                {job.name}
               </span>
             </div>
+            <span className="shrink-0 tabular-nums text-[0.875rem] font-semibold text-primary">
+              {job.matchRate}%
+            </span>
           </li>
         ))}
       </ol>

--- a/src/shared/ui/MatchedJobsCard/MatchedJobsCard.tsx
+++ b/src/shared/ui/MatchedJobsCard/MatchedJobsCard.tsx
@@ -57,13 +57,20 @@ export function MatchedJobsCard({
               >
                 {index + 1}
               </span>
-              <div className="flex min-w-0 flex-1 flex-col gap-1">
-                <FitBadge level={job.fitLevel} className="self-start" />
-                <span className="text-[0.9375rem] font-semibold leading-[1.5] text-gray-900">
+              <div className="flex min-w-0 flex-1 flex-col gap-1 sm:flex-row sm:items-center sm:gap-3">
+                <FitBadge
+                  level={job.fitLevel}
+                  className="self-start sm:order-2 sm:shrink-0"
+                />
+                <span className="text-[0.9375rem] font-semibold leading-[1.5] text-gray-900 sm:order-1 sm:flex-1">
                   {job.name}
                 </span>
+                <span className="hidden shrink-0 tabular-nums text-[0.875rem] font-semibold text-primary sm:order-3 sm:block">
+                  {job.matchRate}%
+                </span>
               </div>
-              <span className="shrink-0 tabular-nums text-[0.875rem] font-semibold text-primary">
+              {/* % 모바일 전용 — li 우측 끝 */}
+              <span className="shrink-0 tabular-nums text-[0.875rem] font-semibold text-primary sm:hidden">
                 {job.matchRate}%
               </span>
             </li>

--- a/src/shared/ui/MatchedJobsCard/MatchedJobsCard.tsx
+++ b/src/shared/ui/MatchedJobsCard/MatchedJobsCard.tsx
@@ -1,7 +1,12 @@
-import type { MatchedJob } from '@/shared/types/job';
+import type { FitLevel, MatchedJob } from '@/shared/types/job';
 import { cn } from '@/shared/utils/cn';
-import { FitBadge } from '@/shared/ui/FitBadge';
 import { Skeleton } from '@/shared/ui/Skeleton';
+
+const fitBarStyle: Record<FitLevel, { fill: string; text: string }> = {
+  '잘 맞아요': { fill: 'bg-success-bg', text: 'text-success' },
+  '도전해볼 수 있어요': { fill: 'bg-warning-bg', text: 'text-warning' },
+  '힘들 수 있어요': { fill: 'bg-error-bg', text: 'text-error' },
+};
 
 type MatchedJobsCardProps = {
   userName: string;
@@ -29,46 +34,48 @@ export function MatchedJobsCard({
         {displayName}님에게 맞는 직종 TOP 3
       </h3>
       {isLoading ? (
-        <ol className="flex flex-col gap-3">
+        <ol className="flex flex-col gap-4">
           {Array.from({ length: 3 }).map((_, i) => (
-            <li
-              key={i}
-              className="flex flex-col gap-2 rounded-md border border-gray-200 px-4 py-3"
-            >
-              <Skeleton className="h-5 w-16 rounded-sm" />
+            <li key={i}>
               <Skeleton className="h-9 w-full rounded-sm" />
             </li>
           ))}
         </ol>
       ) : (
-        <ol className="flex flex-col gap-3" aria-label="매칭 직종 목록">
-          {jobs.map((job, index) => (
-            <li
-              key={job.id}
-              aria-label={`${index + 1}위: ${job.name}, 매칭률 ${job.matchRate}%`}
-              className="flex flex-col gap-2 rounded-md border border-gray-200 bg-white px-4 py-3"
-            >
-              <FitBadge level={job.fitLevel} />
-              <div className="relative h-9 w-full overflow-hidden rounded-sm bg-gray-100">
-                <div
-                  className="absolute inset-y-0 left-0 bg-primary/20"
-                  style={{ width: `${job.matchRate}%` }}
-                  role="progressbar"
-                  aria-valuenow={job.matchRate}
-                  aria-valuemin={0}
-                  aria-valuemax={100}
-                />
-                <div className="absolute inset-0 flex items-center justify-between px-3">
-                  <span className="text-[0.875rem] font-semibold text-gray-900">
-                    {job.name}
-                  </span>
-                  <span className="tabular-nums text-[0.875rem] font-bold text-primary">
-                    {job.matchRate}%
-                  </span>
+        <ol className="flex flex-col gap-4" aria-label="매칭 직종 목록">
+          {jobs.map((job, index) => {
+            const { fill, text } = fitBarStyle[job.fitLevel];
+            return (
+              <li
+                key={job.id}
+                aria-label={`${index + 1}위: ${job.name}, 매칭률 ${job.matchRate}%`}
+              >
+                <div className="relative h-9 w-full overflow-hidden rounded-sm bg-gray-200">
+                  <div
+                    className={cn('absolute inset-y-0 left-0', fill)}
+                    style={{ width: `${job.matchRate}%` }}
+                    role="progressbar"
+                    aria-valuenow={job.matchRate}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                  />
+                  <div className="absolute inset-0 flex items-center justify-between px-3">
+                    <span className="text-[0.875rem] font-semibold text-gray-900">
+                      {job.name}
+                    </span>
+                    <span
+                      className={cn(
+                        'tabular-nums text-[0.875rem] font-bold',
+                        text,
+                      )}
+                    >
+                      {job.matchRate}%
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </li>
-          ))}
+              </li>
+            );
+          })}
         </ol>
       )}
     </div>

--- a/src/shared/ui/MatchedJobsCard/MatchedJobsCard.tsx
+++ b/src/shared/ui/MatchedJobsCard/MatchedJobsCard.tsx
@@ -1,12 +1,7 @@
-import type { FitLevel, MatchedJob } from '@/shared/types/job';
+import type { MatchedJob } from '@/shared/types/job';
 import { cn } from '@/shared/utils/cn';
+import { FitBadge } from '@/shared/ui/FitBadge';
 import { Skeleton } from '@/shared/ui/Skeleton';
-
-const fitBarStyle: Record<FitLevel, { fill: string; text: string }> = {
-  '잘 맞아요': { fill: 'bg-success-bg', text: 'text-success' },
-  '도전해볼 수 있어요': { fill: 'bg-warning-bg', text: 'text-warning' },
-  '힘들 수 있어요': { fill: 'bg-error-bg', text: 'text-error' },
-};
 
 type MatchedJobsCardProps = {
   userName: string;
@@ -34,48 +29,46 @@ export function MatchedJobsCard({
         {displayName}님에게 맞는 직종 TOP 3
       </h3>
       {isLoading ? (
-        <ol className="flex flex-col gap-4">
+        <ol className="flex flex-col gap-3">
           {Array.from({ length: 3 }).map((_, i) => (
-            <li key={i}>
+            <li
+              key={i}
+              className="flex flex-col gap-2 rounded-md border border-gray-200 px-4 py-3"
+            >
+              <Skeleton className="h-5 w-16 rounded-sm" />
               <Skeleton className="h-9 w-full rounded-sm" />
             </li>
           ))}
         </ol>
       ) : (
-        <ol className="flex flex-col gap-4" aria-label="매칭 직종 목록">
-          {jobs.map((job, index) => {
-            const { fill, text } = fitBarStyle[job.fitLevel];
-            return (
-              <li
-                key={job.id}
-                aria-label={`${index + 1}위: ${job.name}, 매칭률 ${job.matchRate}%`}
-              >
-                <div className="relative h-9 w-full overflow-hidden rounded-sm bg-gray-200">
-                  <div
-                    className={cn('absolute inset-y-0 left-0', fill)}
-                    style={{ width: `${job.matchRate}%` }}
-                    role="progressbar"
-                    aria-valuenow={job.matchRate}
-                    aria-valuemin={0}
-                    aria-valuemax={100}
-                  />
-                  <div className="absolute inset-0 flex items-center justify-between px-3">
-                    <span className="text-[0.875rem] font-semibold text-gray-900">
-                      {job.name}
-                    </span>
-                    <span
-                      className={cn(
-                        'tabular-nums text-[0.875rem] font-bold',
-                        text,
-                      )}
-                    >
-                      {job.matchRate}%
-                    </span>
-                  </div>
+        <ol className="flex flex-col gap-3" aria-label="매칭 직종 목록">
+          {jobs.map((job, index) => (
+            <li
+              key={job.id}
+              aria-label={`${index + 1}위: ${job.name}, 매칭률 ${job.matchRate}%`}
+              className="flex flex-col gap-2 rounded-md border border-gray-200 bg-white px-4 py-3"
+            >
+              <FitBadge level={job.fitLevel} />
+              <div className="relative h-9 w-full overflow-hidden rounded-sm bg-gray-100">
+                <div
+                  className="absolute inset-y-0 left-0 bg-primary/20"
+                  style={{ width: `${job.matchRate}%` }}
+                  role="progressbar"
+                  aria-valuenow={job.matchRate}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                />
+                <div className="absolute inset-0 flex items-center justify-between px-3">
+                  <span className="text-[0.875rem] font-semibold text-gray-900">
+                    {job.name}
+                  </span>
+                  <span className="tabular-nums text-[0.875rem] font-bold text-primary">
+                    {job.matchRate}%
+                  </span>
                 </div>
-              </li>
-            );
-          })}
+              </div>
+            </li>
+          ))}
         </ol>
       )}
     </div>

--- a/src/shared/ui/MatchedJobsCard/MatchedJobsCard.tsx
+++ b/src/shared/ui/MatchedJobsCard/MatchedJobsCard.tsx
@@ -1,41 +1,76 @@
 import type { MatchedJob } from '@/shared/types/job';
+import { cn } from '@/shared/utils/cn';
 import { FitBadge } from '@/shared/ui/FitBadge';
+import { Skeleton } from '@/shared/ui/Skeleton';
 
 type MatchedJobsCardProps = {
   userName: string;
   jobs: MatchedJob[];
+  isLoading?: boolean;
+  className?: string;
 };
 
-export function MatchedJobsCard({ userName, jobs }: MatchedJobsCardProps) {
+export function MatchedJobsCard({
+  userName,
+  jobs,
+  isLoading = false,
+  className,
+}: MatchedJobsCardProps) {
+  const displayName = isLoading ? '사용자' : userName;
+
   return (
-    <div className="rounded-lg border border-gray-200 bg-white p-6">
+    <div
+      className={cn(
+        'rounded-lg border border-gray-200 bg-white p-6',
+        className,
+      )}
+    >
       <h3 className="mb-6 border-l-[3px] border-primary pl-[10px] text-[1rem] font-semibold leading-[1.5] text-gray-900">
-        {userName}님에게 맞는 직종 TOP 3
+        {displayName}님에게 맞는 직종 TOP 3
       </h3>
-      <ol className="flex flex-col gap-3" aria-label="매칭 직종 목록">
-        {jobs.map((job, index) => (
-          <li
-            key={job.id}
-            className="flex items-center gap-4 rounded-md border border-gray-200 bg-white px-4 py-3"
-          >
-            <span
-              className="flex h-6 w-6 shrink-0 items-center justify-center rounded-sm bg-gray-100 text-[0.75rem] font-semibold text-gray-500 tabular-nums"
-              aria-label={`${index + 1}위`}
+      {isLoading ? (
+        <ol className="flex flex-col gap-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <li
+              key={i}
+              className="flex flex-col gap-2 rounded-md border border-gray-200 px-4 py-3"
             >
-              {index + 1}
-            </span>
-            <div className="flex min-w-0 flex-1 flex-col gap-1">
-              <FitBadge level={job.fitLevel} className="self-start" />
-              <span className="text-[0.9375rem] font-semibold leading-[1.5] text-gray-900">
-                {job.name}
-              </span>
-            </div>
-            <span className="shrink-0 tabular-nums text-[0.875rem] font-semibold text-primary">
-              {job.matchRate}%
-            </span>
-          </li>
-        ))}
-      </ol>
+              <Skeleton className="h-5 w-16 rounded-sm" />
+              <Skeleton className="h-9 w-full rounded-sm" />
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <ol className="flex flex-col gap-3" aria-label="매칭 직종 목록">
+          {jobs.map((job, index) => (
+            <li
+              key={job.id}
+              aria-label={`${index + 1}위: ${job.name}, 매칭률 ${job.matchRate}%`}
+              className="flex flex-col gap-2 rounded-md border border-gray-200 bg-white px-4 py-3"
+            >
+              <FitBadge level={job.fitLevel} />
+              <div className="relative h-9 w-full overflow-hidden rounded-sm bg-gray-100">
+                <div
+                  className="absolute inset-y-0 left-0 bg-primary/20"
+                  style={{ width: `${job.matchRate}%` }}
+                  role="progressbar"
+                  aria-valuenow={job.matchRate}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                />
+                <div className="absolute inset-0 flex items-center justify-between px-3">
+                  <span className="text-[0.875rem] font-semibold text-gray-900">
+                    {job.name}
+                  </span>
+                  <span className="tabular-nums text-[0.875rem] font-bold text-primary">
+                    {job.matchRate}%
+                  </span>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
     </div>
   );
 }

--- a/src/shared/ui/MatchedJobsCard/MatchedJobsCard.tsx
+++ b/src/shared/ui/MatchedJobsCard/MatchedJobsCard.tsx
@@ -33,10 +33,14 @@ export function MatchedJobsCard({
           {Array.from({ length: 3 }).map((_, i) => (
             <li
               key={i}
-              className="flex flex-col gap-2 rounded-md border border-gray-200 px-4 py-3"
+              className="flex items-center gap-4 rounded-md border border-gray-200 px-4 py-3"
             >
-              <Skeleton className="h-5 w-16 rounded-sm" />
-              <Skeleton className="h-9 w-full rounded-sm" />
+              <Skeleton className="h-6 w-6 shrink-0 rounded-sm" />
+              <div className="flex min-w-0 flex-1 flex-col gap-1">
+                <Skeleton className="h-5 w-16 rounded-sm" />
+                <Skeleton className="h-5 w-3/4 rounded-sm" />
+              </div>
+              <Skeleton className="h-5 w-10 shrink-0 rounded-sm" />
             </li>
           ))}
         </ol>
@@ -45,28 +49,23 @@ export function MatchedJobsCard({
           {jobs.map((job, index) => (
             <li
               key={job.id}
-              aria-label={`${index + 1}위: ${job.name}, 매칭률 ${job.matchRate}%`}
-              className="flex flex-col gap-2 rounded-md border border-gray-200 bg-white px-4 py-3"
+              className="flex items-center gap-4 rounded-md border border-gray-200 bg-white px-4 py-3"
             >
-              <FitBadge level={job.fitLevel} />
-              <div className="relative h-9 w-full overflow-hidden rounded-sm bg-gray-100">
-                <div
-                  className="absolute inset-y-0 left-0 bg-primary/20"
-                  style={{ width: `${job.matchRate}%` }}
-                  role="progressbar"
-                  aria-valuenow={job.matchRate}
-                  aria-valuemin={0}
-                  aria-valuemax={100}
-                />
-                <div className="absolute inset-0 flex items-center justify-between px-3">
-                  <span className="text-[0.875rem] font-semibold text-gray-900">
-                    {job.name}
-                  </span>
-                  <span className="tabular-nums text-[0.875rem] font-bold text-primary">
-                    {job.matchRate}%
-                  </span>
-                </div>
+              <span
+                className="flex h-6 w-6 shrink-0 items-center justify-center rounded-sm bg-gray-100 text-[0.75rem] font-semibold text-gray-500 tabular-nums"
+                aria-label={`${index + 1}위`}
+              >
+                {index + 1}
+              </span>
+              <div className="flex min-w-0 flex-1 flex-col gap-1">
+                <FitBadge level={job.fitLevel} className="self-start" />
+                <span className="text-[0.9375rem] font-semibold leading-[1.5] text-gray-900">
+                  {job.name}
+                </span>
               </div>
+              <span className="shrink-0 tabular-nums text-[0.875rem] font-semibold text-primary">
+                {job.matchRate}%
+              </span>
             </li>
           ))}
         </ol>

--- a/src/shared/ui/PersonalityRadarChart/PersonalityRadarChart.tsx
+++ b/src/shared/ui/PersonalityRadarChart/PersonalityRadarChart.tsx
@@ -6,6 +6,7 @@ import {
   RadarChart,
   PolarGrid,
   PolarAngleAxis,
+  PolarRadiusAxis,
   ResponsiveContainer,
   Tooltip,
 } from 'recharts';
@@ -43,6 +44,7 @@ type PersonalityRadarChartProps = {
 
 export function PersonalityRadarChart({ data }: PersonalityRadarChartProps) {
   const listId = useId();
+  const maxValue = data[0]?.fullMark ?? 100;
 
   return (
     <div className="w-full max-w-[320px]">
@@ -57,6 +59,11 @@ export function PersonalityRadarChart({ data }: PersonalityRadarChartProps) {
             margin={{ top: 16, right: 24, bottom: 16, left: 24 }}
           >
             <PolarGrid stroke="var(--gray-200)" strokeWidth={1} />
+            <PolarRadiusAxis
+              domain={[0, maxValue]}
+              tick={false}
+              axisLine={false}
+            />
             <PolarAngleAxis
               dataKey="subject"
               tick={{

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -26,7 +26,7 @@ export function Header({ initialUser }: HeaderProps) {
   const { mutate: testLogin, isPending: isTestLoginPending } = useTestLogin();
   const { mutate: testLogout, isPending: isTestLogoutPending } =
     useTestLogout();
-  const { theme, toggle: toggleTheme, mounted: themeMounted } = useDarkMode();
+  const { theme, toggle: toggleTheme, mounted } = useDarkMode();
 
   return (
     <header
@@ -44,12 +44,7 @@ export function Header({ initialUser }: HeaderProps) {
         </Link>
 
         <div className="flex items-center gap-2">
-          <div className="flex items-center gap-2.5">
-            {themeMounted && (
-              <span className="text-[0.75rem] font-semibold leading-none text-gray-500">
-                {theme === 'dark' ? '다크 모드' : '라이트 모드'}
-              </span>
-            )}
+          {mounted && (
             <button
               type="button"
               role="switch"
@@ -66,22 +61,22 @@ export function Header({ initialUser }: HeaderProps) {
               >
                 {theme === 'dark' ? (
                   <Moon
-                    size={10}
-                    strokeWidth={1.5}
+                    size={11}
+                    strokeWidth={2}
                     className="text-primary"
                     aria-hidden="true"
                   />
                 ) : (
                   <Sun
-                    size={10}
-                    strokeWidth={1.5}
-                    className="text-gray-400"
+                    size={11}
+                    strokeWidth={2}
+                    className="text-gray-600"
                     aria-hidden="true"
                   />
                 )}
               </span>
             </button>
-          </div>
+          )}
 
           {!user && (
             <nav aria-label="로그인 메뉴" className="flex items-center gap-2">


### PR DESCRIPTION
## 개요
헤더 다크모드 토글 UI 개선, 다크모드 로딩 텍스트 색상 수정, 모바일 카드 레이아웃 오버플로우 및 매칭 직종 카드 모바일 레이아웃 개선.

## 주요 변경 사항
- 헤더 다크/라이트 모드 전환 버튼에서 텍스트 제거, Sun/Moon 아이콘 가시성 개선
- LoadingOverlay(AI 검사 로딩) 텍스트 색상을 CSS 변수 토큰(`text-gray-700`)으로 변경 → 다크모드 대응
- 채용공고 카드 grid 아이템에 `min-w-0` 추가, JobCard `article`에 `overflow-hidden` 추가 → 모바일 카드 잘림 수정
- MatchedJobsCard 아이템 레이아웃 변경: FitBadge → 직종명(2줄 허용) 세로 배치, 매칭률(%)는 우측 끝 세로 중앙 정렬

Closes #159