### PR TITLE
refactor: survey 페이지 SurveyContent 컴포넌트 분리 #161

### DIFF
--- a/src/app/survey/page.tsx
+++ b/src/app/survey/page.tsx
@@ -1,45 +1,5 @@
-'use client';
-
 import { Suspense } from 'react';
-import { useSearchParams } from 'next/navigation';
-import { SurveyForm } from '@/features/survey/ui/SurveyForm';
-import { useSurveyForm } from '@/features/survey/hooks/useSurveyForm';
-import { usePreventNavigation } from '@/features/survey/hooks/usePreventNavigation';
-
-function SurveyContent() {
-  const searchParams = useSearchParams();
-  const mode = searchParams.get('mode') === 'edit' ? 'edit' : 'create';
-  const form = useSurveyForm(mode);
-  const { isBlocking, onStay, onLeave } = usePreventNavigation(form.isDirty);
-
-  return (
-    <SurveyForm
-      mode={form.mode}
-      step={form.step}
-      register={form.register}
-      errors={form.errors}
-      isSubmitting={form.isSubmitting}
-      isMatching={form.isMatching}
-      isMatchError={form.isMatchError}
-      isComplete={form.isComplete}
-      isBlocking={isBlocking}
-      sidoList={form.sidoList}
-      watchedPrimaryRegion={form.watchedPrimaryRegion}
-      watchedDisabilityType={form.watchedDisabilityType}
-      watchedHopeActivities={form.watchedHopeActivities}
-      onPrimaryRegionChange={form.onPrimaryRegionChange}
-      onDisabilityTypeChange={form.onDisabilityTypeChange}
-      onHopeActivitiesChange={form.onHopeActivitiesChange}
-      onNextStep={form.onNextStep}
-      onPrevStep={form.onPrevStep}
-      onSubmit={form.onSubmit}
-      onCompleteConfirm={form.onCompleteConfirm}
-      onMatchErrorClose={form.onMatchErrorClose}
-      onStay={onStay}
-      onLeave={onLeave}
-    />
-  );
-}
+import { SurveyContent } from '@/features/survey/ui/SurveyContent';
 
 export default function SurveyPage() {
   return (

--- a/src/features/survey/ui/SurveyContent.tsx
+++ b/src/features/survey/ui/SurveyContent.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import { SurveyForm } from './SurveyForm';
+import { useSurveyForm } from '../hooks/useSurveyForm';
+import { usePreventNavigation } from '../hooks/usePreventNavigation';
+
+export function SurveyContent() {
+  const searchParams = useSearchParams();
+  const mode = searchParams.get('mode') === 'edit' ? 'edit' : 'create';
+  const form = useSurveyForm(mode);
+  const { isBlocking, onStay, onLeave } = usePreventNavigation(form.isDirty);
+
+  return (
+    <SurveyForm
+      mode={form.mode}
+      step={form.step}
+      register={form.register}
+      errors={form.errors}
+      isSubmitting={form.isSubmitting}
+      isMatching={form.isMatching}
+      isMatchError={form.isMatchError}
+      isComplete={form.isComplete}
+      isBlocking={isBlocking}
+      sidoList={form.sidoList}
+      watchedPrimaryRegion={form.watchedPrimaryRegion}
+      watchedDisabilityType={form.watchedDisabilityType}
+      watchedHopeActivities={form.watchedHopeActivities}
+      onPrimaryRegionChange={form.onPrimaryRegionChange}
+      onDisabilityTypeChange={form.onDisabilityTypeChange}
+      onHopeActivitiesChange={form.onHopeActivitiesChange}
+      onNextStep={form.onNextStep}
+      onPrevStep={form.onPrevStep}
+      onSubmit={form.onSubmit}
+      onCompleteConfirm={form.onCompleteConfirm}
+      onMatchErrorClose={form.onMatchErrorClose}
+      onStay={onStay}
+      onLeave={onLeave}
+    />
+  );
+}


### PR DESCRIPTION
## 개요
`/survey` 페이지에 인라인 정의되어 있던 `SurveyContent` 컴포넌트를 features 레이어로 분리해 `app/`이 라우팅 전용이 되도록 정리했습니다.

## 주요 변경 사항
- `src/features/survey/ui/SurveyContent.tsx` 신규 생성 (`useSearchParams` + `useSurveyForm` + `usePreventNavigation` 연결, props 전달 로직)
- `src/app/survey/page.tsx`에서 인라인 `SurveyContent` 제거, `'use client'` 제거 — `Suspense` 래핑만 담당
- CLAUDE.md 4장 FSD 규칙(app은 라우팅 전용) 및 `/profile` 페이지 구조와 일관성 확보

Closes #161