### PR TITLE
refactor: 쿼리키를 QUERY_KEYS 객체로 중앙화 #163

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,36 @@ export const useJobs = () => useQuery(...);
 export const useBookmarkToggle = () => useMutation(...);
 ```
 
+### 쿼리키 관리 (필수)
+
+모든 TanStack Query 쿼리키는 반드시 `shared/utils/queryKeys.ts`의 `QUERY_KEYS` 객체를 참조한다.
+
+- 문자열 리터럴 직접 사용 절대 금지
+- 훅 파일 내부에 쿼리키 상수 선언 금지
+- 새 쿼리키 추가 시 `QUERY_KEYS` 객체에만 등록
+
+```ts
+// 금지
+useQuery({ queryKey: ['profile'], ... });
+export const PROFILE_QUERY_KEY = ['profile'] as const;
+
+// 필수
+import { QUERY_KEYS } from '@/shared/utils/queryKeys';
+useQuery({ queryKey: QUERY_KEYS.profile, ... });
+```
+
+**`shared/utils/queryKeys.ts` 현재 등록된 키:**
+
+```ts
+export const QUERY_KEYS = {
+  currentUser: ['currentUser'],
+  profile:     ['profile'],
+  matchResult: ['match-result'],
+  jobPostings: ['job-postings'],
+  bookmarks:   ['bookmarks'],
+} as const;
+```
+
 ---
 
 ## 8. API / Auth Rules (Canonical)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,7 +13,7 @@ import { supabaseFetch } from '@/shared/api/supabaseFetch';
 import { getServerSession } from '@/shared/utils/serverSession';
 import type { CurrentUser } from '@/shared/types/user';
 import { TEST_USER } from '@/shared/utils/testUser';
-import { CURRENT_USER_QUERY_KEY } from '@/shared/hooks/useCurrentUser';
+import { QUERY_KEYS } from '@/shared/utils/queryKeys';
 import './globals.css';
 
 const pretendard = localFont({
@@ -107,7 +107,7 @@ export default async function RootLayout({
   const initialUser = await getInitialUser();
 
   const queryClient = new QueryClient();
-  queryClient.setQueryData(CURRENT_USER_QUERY_KEY, initialUser);
+  queryClient.setQueryData(QUERY_KEYS.currentUser, initialUser);
   const dehydratedState = dehydrate(queryClient);
 
   return (

--- a/src/features/dashboard/hooks/useBookmarkToggle.ts
+++ b/src/features/dashboard/hooks/useBookmarkToggle.ts
@@ -5,7 +5,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import type { JobPosting } from '@/shared/types/job';
 import { addBookmark, removeBookmark } from '../api/bookmarkApi';
-import { JOB_POSTINGS_QUERY_KEY } from './useJobPostings';
+import { QUERY_KEYS } from '@/shared/utils/queryKeys';
 import { useCurrentUser } from '@/shared/hooks/useCurrentUser';
 
 export function useBookmarkToggle() {
@@ -26,14 +26,14 @@ export function useBookmarkToggle() {
           ),
 
     onMutate: async (job) => {
-      await queryClient.cancelQueries({ queryKey: JOB_POSTINGS_QUERY_KEY });
+      await queryClient.cancelQueries({ queryKey: QUERY_KEYS.jobPostings });
 
       const previous = queryClient.getQueryData<JobPosting[]>(
-        JOB_POSTINGS_QUERY_KEY,
+        QUERY_KEYS.jobPostings,
       );
 
       queryClient.setQueryData<JobPosting[]>(
-        JOB_POSTINGS_QUERY_KEY,
+        QUERY_KEYS.jobPostings,
         (old = []) =>
           old.map((p) =>
             p.id === job.id ? { ...p, bookmarked: !p.bookmarked } : p,
@@ -45,7 +45,7 @@ export function useBookmarkToggle() {
 
     onError: (_err, _job, ctx) => {
       if (ctx?.previous) {
-        queryClient.setQueryData(JOB_POSTINGS_QUERY_KEY, ctx.previous);
+        queryClient.setQueryData(QUERY_KEYS.jobPostings, ctx.previous);
       }
     },
   });

--- a/src/features/dashboard/hooks/useDashboard.ts
+++ b/src/features/dashboard/hooks/useDashboard.ts
@@ -2,9 +2,8 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { getProfile } from '@/features/profile/api/profileApi';
-import { PROFILE_QUERY_KEY } from '@/features/profile/hooks/useProfile';
 import { getMatchResult } from '@/features/match/api/matchApi';
-import { MATCH_RESULT_QUERY_KEY } from '@/features/match/hooks/useMatchResult';
+import { QUERY_KEYS } from '@/shared/utils/queryKeys';
 import {
   toPersonalityAxes,
   toMatchedJobs,
@@ -12,12 +11,12 @@ import {
 
 export function useDashboard() {
   const { data: profile, isPending: isProfilePending } = useQuery({
-    queryKey: PROFILE_QUERY_KEY,
+    queryKey: QUERY_KEYS.profile,
     queryFn: getProfile,
   });
 
   const { data: matchResult, isPending: isMatchPending } = useQuery({
-    queryKey: MATCH_RESULT_QUERY_KEY,
+    queryKey: QUERY_KEYS.matchResult,
     queryFn: getMatchResult,
   });
 

--- a/src/features/dashboard/hooks/useJobPostings.ts
+++ b/src/features/dashboard/hooks/useJobPostings.ts
@@ -2,13 +2,11 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { getJobPostings } from '../api/jobPostingsApi';
-import { JOB_POSTINGS_QUERY_KEY } from '../utils/queryKeys';
-
-export { JOB_POSTINGS_QUERY_KEY };
+import { QUERY_KEYS } from '@/shared/utils/queryKeys';
 
 export function useJobPostings() {
   return useQuery({
-    queryKey: JOB_POSTINGS_QUERY_KEY,
+    queryKey: QUERY_KEYS.jobPostings,
     queryFn: ({ signal }) => getJobPostings(signal),
     staleTime: 5 * 60 * 1000,
   });

--- a/src/features/dashboard/ui/JobListPrefetcher.tsx
+++ b/src/features/dashboard/ui/JobListPrefetcher.tsx
@@ -4,7 +4,7 @@ import {
   HydrationBoundary,
 } from '@tanstack/react-query';
 import { getJobPostingsData } from '../api/jobPostingsServerApi';
-import { JOB_POSTINGS_QUERY_KEY } from '../utils/queryKeys';
+import { QUERY_KEYS } from '@/shared/utils/queryKeys';
 import { JobListClient } from './JobListClient';
 
 type Props = {
@@ -20,7 +20,7 @@ export async function JobListPrefetcher({
 }: Props) {
   const queryClient = new QueryClient();
   await queryClient.prefetchQuery({
-    queryKey: JOB_POSTINGS_QUERY_KEY,
+    queryKey: QUERY_KEYS.jobPostings,
     queryFn: () => getJobPostingsData(userId),
   });
 

--- a/src/features/dashboard/utils/queryKeys.ts
+++ b/src/features/dashboard/utils/queryKeys.ts
@@ -1,1 +1,0 @@
-export const JOB_POSTINGS_QUERY_KEY = ['job-postings'] as const;

--- a/src/features/match/hooks/useGenerateMatch.ts
+++ b/src/features/match/hooks/useGenerateMatch.ts
@@ -2,7 +2,7 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { generateMatch } from '../api/matchApi';
-import { MATCH_RESULT_QUERY_KEY } from './useMatchResult';
+import { QUERY_KEYS } from '@/shared/utils/queryKeys';
 
 export function useGenerateMatch() {
   const queryClient = useQueryClient();
@@ -10,7 +10,7 @@ export function useGenerateMatch() {
   return useMutation({
     mutationFn: () => generateMatch(),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: MATCH_RESULT_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.matchResult });
     },
   });
 }

--- a/src/features/match/hooks/useMatchResult.ts
+++ b/src/features/match/hooks/useMatchResult.ts
@@ -3,14 +3,13 @@
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
 import { getMatchResult } from '../api/matchApi';
 import type { MatchResult } from '@/shared/types/match';
-
-export const MATCH_RESULT_QUERY_KEY = ['match-result'] as const;
+import { QUERY_KEYS } from '@/shared/utils/queryKeys';
 
 export function useMatchResult(
   options?: Omit<UseQueryOptions<MatchResult | null>, 'queryKey' | 'queryFn'>,
 ) {
   return useQuery({
-    queryKey: MATCH_RESULT_QUERY_KEY,
+    queryKey: QUERY_KEYS.matchResult,
     queryFn: getMatchResult,
     ...options,
   });

--- a/src/features/profile/hooks/useBookmarkRemove.ts
+++ b/src/features/profile/hooks/useBookmarkRemove.ts
@@ -5,7 +5,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import type { Bookmark } from '@/shared/types/bookmark';
 import { removeBookmark } from '../api/bookmarksApi';
-import { BOOKMARKS_QUERY_KEY } from './useScrapedJobs';
+import { QUERY_KEYS } from '@/shared/utils/queryKeys';
 import { useCurrentUser } from '@/shared/hooks/useCurrentUser';
 
 export function useBookmarkRemove() {
@@ -17,12 +17,13 @@ export function useBookmarkRemove() {
     mutationFn: (postingUrl: string) => removeBookmark(postingUrl),
 
     onMutate: async (postingUrl) => {
-      await queryClient.cancelQueries({ queryKey: BOOKMARKS_QUERY_KEY });
+      await queryClient.cancelQueries({ queryKey: QUERY_KEYS.bookmarks });
 
-      const previous =
-        queryClient.getQueryData<Bookmark[]>(BOOKMARKS_QUERY_KEY);
+      const previous = queryClient.getQueryData<Bookmark[]>(
+        QUERY_KEYS.bookmarks,
+      );
 
-      queryClient.setQueryData<Bookmark[]>(BOOKMARKS_QUERY_KEY, (old = []) =>
+      queryClient.setQueryData<Bookmark[]>(QUERY_KEYS.bookmarks, (old = []) =>
         old.filter((b) => b.postingUrl !== postingUrl),
       );
 
@@ -31,7 +32,7 @@ export function useBookmarkRemove() {
 
     onError: (_err, _url, ctx) => {
       if (ctx?.previous) {
-        queryClient.setQueryData(BOOKMARKS_QUERY_KEY, ctx.previous);
+        queryClient.setQueryData(QUERY_KEYS.bookmarks, ctx.previous);
       }
     },
   });

--- a/src/features/profile/hooks/useProfile.ts
+++ b/src/features/profile/hooks/useProfile.ts
@@ -9,6 +9,7 @@ import {
 } from '@/features/match/utils/convert';
 import type { Profile } from '@/shared/types/profile';
 import type { UserProfile } from '@/shared/types/userProfile';
+import { QUERY_KEYS } from '@/shared/utils/queryKeys';
 
 function toUserProfile(p: Profile): UserProfile {
   return {
@@ -29,11 +30,9 @@ function toUserProfile(p: Profile): UserProfile {
   };
 }
 
-export const PROFILE_QUERY_KEY = ['profile'] as const;
-
 export function useProfile() {
   const { data: profile, isLoading: isProfileLoading } = useQuery({
-    queryKey: PROFILE_QUERY_KEY,
+    queryKey: QUERY_KEYS.profile,
     queryFn: getProfile,
   });
 

--- a/src/features/profile/hooks/useScrapedJobs.ts
+++ b/src/features/profile/hooks/useScrapedJobs.ts
@@ -3,12 +3,11 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { getBookmarks } from '../api/bookmarksApi';
-
-export const BOOKMARKS_QUERY_KEY = ['bookmarks'] as const;
+import { QUERY_KEYS } from '@/shared/utils/queryKeys';
 
 export function useScrapedJobs() {
   return useQuery({
-    queryKey: BOOKMARKS_QUERY_KEY,
+    queryKey: QUERY_KEYS.bookmarks,
     queryFn: getBookmarks,
   });
 }

--- a/src/features/survey/hooks/useSurveyForm.ts
+++ b/src/features/survey/hooks/useSurveyForm.ts
@@ -16,11 +16,9 @@ import {
   HOPE_ACTIVITIES_VALUES,
 } from '../utils/options';
 import { submitSurvey } from '../api/surveyApi';
-import { JOB_POSTINGS_QUERY_KEY } from '@/features/dashboard/hooks/useJobPostings';
 import { generateMatch } from '@/features/match/api/matchApi';
-import { MATCH_RESULT_QUERY_KEY } from '@/features/match/hooks/useMatchResult';
 import { getProfile } from '@/features/profile/api/profileApi';
-import { PROFILE_QUERY_KEY } from '@/features/profile/hooks/useProfile';
+import { QUERY_KEYS } from '@/shared/utils/queryKeys';
 import type { Profile } from '@/shared/types/profile';
 
 export type { SurveyFormValues };
@@ -99,7 +97,7 @@ export function useSurveyForm(mode: 'create' | 'edit' = 'create') {
   });
 
   const { data: existingProfile } = useQuery({
-    queryKey: PROFILE_QUERY_KEY,
+    queryKey: QUERY_KEYS.profile,
     queryFn: getProfile,
     enabled: mode === 'edit',
   });
@@ -188,15 +186,15 @@ export function useSurveyForm(mode: 'create' | 'edit' = 'create') {
       hope_activities: activities,
     });
 
-    queryClient.invalidateQueries({ queryKey: PROFILE_QUERY_KEY });
-    queryClient.removeQueries({ queryKey: JOB_POSTINGS_QUERY_KEY });
+    queryClient.invalidateQueries({ queryKey: QUERY_KEYS.profile });
+    queryClient.removeQueries({ queryKey: QUERY_KEYS.jobPostings });
     localStorage.removeItem('matchzoom-job-sigungu-filter');
     localStorage.removeItem('matchzoom-job-fitlevel-filter');
     setIsMatching(true);
 
     try {
       await generateMatch();
-      queryClient.invalidateQueries({ queryKey: MATCH_RESULT_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.matchResult });
       setIsComplete(true);
     } catch {
       setIsMatchError(true);

--- a/src/shared/hooks/useCurrentUser.ts
+++ b/src/shared/hooks/useCurrentUser.ts
@@ -1,24 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { getCurrentUser } from '@/shared/api/userApi';
+import { QUERY_KEYS } from '@/shared/utils/queryKeys';
 
-export const CURRENT_USER_QUERY_KEY = ['currentUser'] as const;
-
-/**
- * 로그인한 유저 정보를 가져오는 React Query 훅.
- *
- * - 미인증 상태(401)에서는 null을 반환한다 (에러로 throw하지 않음)
- * - 컴포넌트 어디서든 호출 가능 — 전역 유저 상태 역할
- *
- * @example
- * ```tsx
- * const { data: user } = useCurrentUser();
- * if (!user) return <GuestView />;
- * return <span>{user.nickname}</span>;
- * ```
- */
 export function useCurrentUser() {
   return useQuery({
-    queryKey: CURRENT_USER_QUERY_KEY,
+    queryKey: QUERY_KEYS.currentUser,
     queryFn: async () => {
       try {
         return await getCurrentUser();

--- a/src/shared/hooks/useCurrentUser.ts
+++ b/src/shared/hooks/useCurrentUser.ts
@@ -2,6 +2,12 @@ import { useQuery } from '@tanstack/react-query';
 import { getCurrentUser } from '@/shared/api/userApi';
 import { QUERY_KEYS } from '@/shared/utils/queryKeys';
 
+/**
+ * 로그인한 유저 정보를 가져오는 React Query 훅.
+ *
+ * - 미인증 상태(401)에서는 null을 반환한다 (에러로 throw하지 않음)
+ * - 컴포넌트 어디서든 호출 가능 — 전역 유저 상태 역할
+ */
 export function useCurrentUser() {
   return useQuery({
     queryKey: QUERY_KEYS.currentUser,

--- a/src/shared/hooks/useLogout.ts
+++ b/src/shared/hooks/useLogout.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { logout } from '@/shared/api/authApi';
-import { CURRENT_USER_QUERY_KEY } from './useCurrentUser';
+import { QUERY_KEYS } from '@/shared/utils/queryKeys';
 import {
   STORAGE_KEY_JOB_SIGUNGU_FILTER,
   STORAGE_KEY_JOB_FITLEVEL_FILTER,
@@ -12,7 +12,7 @@ export function useLogout() {
   return useMutation({
     mutationFn: logout,
     onSuccess: () => {
-      queryClient.setQueryData(CURRENT_USER_QUERY_KEY, null);
+      queryClient.setQueryData(QUERY_KEYS.currentUser, null);
       localStorage.removeItem(STORAGE_KEY_JOB_SIGUNGU_FILTER);
       localStorage.removeItem(STORAGE_KEY_JOB_FITLEVEL_FILTER);
       window.location.href = '/';

--- a/src/shared/hooks/useTestLogout.ts
+++ b/src/shared/hooks/useTestLogout.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { testLogout } from '@/shared/api/authApi';
-import { CURRENT_USER_QUERY_KEY } from './useCurrentUser';
+import { QUERY_KEYS } from '@/shared/utils/queryKeys';
 import {
   STORAGE_KEY_JOB_SIGUNGU_FILTER,
   STORAGE_KEY_JOB_FITLEVEL_FILTER,
@@ -12,7 +12,7 @@ export function useTestLogout() {
   return useMutation({
     mutationFn: testLogout,
     onSuccess: () => {
-      queryClient.setQueryData(CURRENT_USER_QUERY_KEY, null);
+      queryClient.setQueryData(QUERY_KEYS.currentUser, null);
       localStorage.removeItem(STORAGE_KEY_JOB_SIGUNGU_FILTER);
       localStorage.removeItem(STORAGE_KEY_JOB_FITLEVEL_FILTER);
       window.location.href = '/';

--- a/src/shared/utils/queryKeys.ts
+++ b/src/shared/utils/queryKeys.ts
@@ -1,0 +1,7 @@
+export const QUERY_KEYS = {
+  currentUser: ['currentUser'] as const,
+  profile: ['profile'] as const,
+  matchResult: ['match-result'] as const,
+  jobPostings: ['job-postings'] as const,
+  bookmarks: ['bookmarks'] as const,
+} as const;

--- a/src/shared/utils/queryKeys.ts
+++ b/src/shared/utils/queryKeys.ts
@@ -1,7 +1,7 @@
 export const QUERY_KEYS = {
-  currentUser: ['currentUser'] as const,
-  profile: ['profile'] as const,
-  matchResult: ['match-result'] as const,
-  jobPostings: ['job-postings'] as const,
-  bookmarks: ['bookmarks'] as const,
+  currentUser: ['currentUser'],
+  profile: ['profile'],
+  matchResult: ['match-result'],
+  jobPostings: ['job-postings'],
+  bookmarks: ['bookmarks'],
 } as const;


### PR DESCRIPTION
## 개요
각 훅 파일에 분산되어 있던 쿼리키 상수 5개를 `shared/utils/queryKeys.ts`의 `QUERY_KEYS` 객체 하나로 통합했습니다.

## 주요 변경 사항
- `src/shared/utils/queryKeys.ts` 신규 생성 — `QUERY_KEYS.currentUser / profile / matchResult / jobPostings / bookmarks`
- 기존 각 훅 파일의 개별 쿼리키 상수 선언 제거 (16개 파일 수정)
- `src/features/dashboard/utils/queryKeys.ts` 삭제
- `CLAUDE.md` 섹션 7에 쿼리키 관리 규칙 추가 (문자열 직접 사용 및 훅 내부 선언 금지)

Closes #163