### PR TITLE
fix: 필터 UX 개선 및 중복 코드 정리 #178

### DIFF
--- a/src/app/api/job-postings/route.ts
+++ b/src/app/api/job-postings/route.ts
@@ -1,17 +1,6 @@
 import { createAuthorizedRoute } from '@/shared/api/createAuthorizedRoute';
 import { getJobPostingsPage } from '@/features/dashboard/api/jobPostingsServerApi';
-import type { FitLevel } from '@/shared/types/job';
-
-function parseFitLevel(v: string | null): FitLevel | null {
-  if (
-    v === '잘 맞아요' ||
-    v === '도전해볼 수 있어요' ||
-    v === '힘들 수 있어요'
-  ) {
-    return v;
-  }
-  return null;
-}
+import { parseFitLevel } from '@/features/dashboard/utils/parseFitLevel';
 
 export const GET = createAuthorizedRoute(async ({ userId, request }) => {
   const { searchParams } = new URL(request.url);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,19 +7,7 @@ import { getDashboardData } from '@/features/dashboard/api/dashboardServerApi';
 import { LandingPage } from '@/features/landing';
 import { toPersonalityAxes, toMatchedJobs } from '@/shared/utils/matchConvert';
 import { TEST_PROFILE, TEST_MATCH } from '@/shared/constants/testUser';
-import type { FitLevel } from '@/shared/types/job';
-
-const VALID_FIT_LEVELS: readonly FitLevel[] = [
-  '잘 맞아요',
-  '도전해볼 수 있어요',
-  '힘들 수 있어요',
-];
-
-function parseFitLevel(value: string | undefined): FitLevel | null {
-  if (value && (VALID_FIT_LEVELS as string[]).includes(value))
-    return value as FitLevel;
-  return null;
-}
+import { parseFitLevel } from '@/features/dashboard/utils/parseFitLevel';
 
 export default async function Home({
   searchParams,

--- a/src/features/dashboard/hooks/useJobFilter.ts
+++ b/src/features/dashboard/hooks/useJobFilter.ts
@@ -3,18 +3,7 @@
 import { useCallback } from 'react';
 import { useRouter, useSearchParams, usePathname } from 'next/navigation';
 import type { FitLevel } from '@/shared/types/job';
-
-const VALID_FIT_LEVELS: readonly FitLevel[] = [
-  '잘 맞아요',
-  '도전해볼 수 있어요',
-  '힘들 수 있어요',
-];
-
-function parseFitLevel(value: string | null): FitLevel | null {
-  if (value && (VALID_FIT_LEVELS as string[]).includes(value))
-    return value as FitLevel;
-  return null;
-}
+import { parseFitLevel } from '../utils/parseFitLevel';
 
 export function useJobFilter() {
   const router = useRouter();
@@ -38,7 +27,7 @@ export function useJobFilter() {
       }
 
       const qs = params.toString();
-      router.replace(qs ? `${pathname}?${qs}` : pathname);
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
     },
     [router, pathname, searchParams],
   );

--- a/src/features/dashboard/hooks/useJobPostings.ts
+++ b/src/features/dashboard/hooks/useJobPostings.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, keepPreviousData } from '@tanstack/react-query';
 
 import { getJobPostingsPage } from '../api/jobPostingsApi';
 import {
@@ -25,5 +25,6 @@ export function useJobPostings(filters: JobPostingsListFilters) {
     initialPageParam: 0,
     getNextPageParam: (lastPage) => lastPage.nextCursor,
     staleTime: 5 * 60 * 1000,
+    placeholderData: keepPreviousData,
   });
 }

--- a/src/features/dashboard/ui/JobListSection.tsx
+++ b/src/features/dashboard/ui/JobListSection.tsx
@@ -4,6 +4,7 @@ import type { FitLevel, JobPosting } from '@/shared/types/job';
 import { Skeleton } from '@/shared/ui/Skeleton';
 import { JobRegionFilter } from './JobRegionFilter';
 import { VirtualJobList } from './VirtualJobList';
+import { JOB_POSTINGS_PAGE_SIZE } from '../constants/jobPostingsConfig';
 
 type JobListSectionProps = {
   userName: string;
@@ -89,7 +90,7 @@ export function JobListSection({
           aria-label="채용공고 로딩 중"
           className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3"
         >
-          {Array.from({ length: 6 }).map((_, i) => (
+          {Array.from({ length: JOB_POSTINGS_PAGE_SIZE }).map((_, i) => (
             <li
               key={i}
               className="min-w-0 rounded-lg border border-gray-200 p-5"

--- a/src/features/dashboard/ui/JobListSkeleton.tsx
+++ b/src/features/dashboard/ui/JobListSkeleton.tsx
@@ -1,4 +1,5 @@
 import { Skeleton } from '@/shared/ui/Skeleton';
+import { JOB_POSTINGS_PAGE_SIZE } from '../constants/jobPostingsConfig';
 
 export function JobListSkeleton() {
   return (
@@ -13,7 +14,7 @@ export function JobListSkeleton() {
         className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3"
         aria-label="채용공고 로딩 중"
       >
-        {Array.from({ length: 6 }).map((_, i) => (
+        {Array.from({ length: JOB_POSTINGS_PAGE_SIZE }).map((_, i) => (
           <li key={i} className="rounded-lg border border-gray-200 p-5">
             <Skeleton className="mb-3 h-6 w-16 rounded-sm" />
             <Skeleton className="mb-2 h-5 w-3/4 rounded-sm" />

--- a/src/features/dashboard/ui/JobRegionFilter.tsx
+++ b/src/features/dashboard/ui/JobRegionFilter.tsx
@@ -86,22 +86,6 @@ export function JobRegionFilter({
           aria-label="적합도 필터"
           className="mb-8 flex flex-wrap gap-2"
         >
-          <button
-            type="button"
-            aria-pressed={selectedFitLevel === null}
-            onClick={() => onSelectFitLevel(null)}
-            className={cn(
-              'h-8 cursor-pointer rounded-sm border px-3 text-[0.8125rem] font-semibold transition-colors',
-              selectedFitLevel === null
-                ? 'border-primary bg-primary-tag text-primary'
-                : 'border-gray-200 bg-white text-gray-700 hover:border-gray-300 hover:bg-gray-50',
-            )}
-          >
-            전체
-          </button>
-
-          <div aria-hidden="true" className="w-px self-stretch bg-gray-300" />
-
           {fitLevelList.map((fitLevel) => (
             <button
               key={fitLevel}

--- a/src/features/dashboard/utils/parseFitLevel.ts
+++ b/src/features/dashboard/utils/parseFitLevel.ts
@@ -1,0 +1,15 @@
+import type { FitLevel } from '@/shared/types/job';
+
+const VALID_FIT_LEVELS: readonly FitLevel[] = [
+  '잘 맞아요',
+  '도전해볼 수 있어요',
+  '힘들 수 있어요',
+];
+
+export function parseFitLevel(
+  value: string | null | undefined,
+): FitLevel | null {
+  if (value && (VALID_FIT_LEVELS as string[]).includes(value))
+    return value as FitLevel;
+  return null;
+}


### PR DESCRIPTION
## 개요
PR #174(무한스크롤·URL 필터)에서 남아 있던 UX 버그 2건을 수정하고, 중복 코드를 정리함

## 주요 변경 사항
- **스크롤 리셋 수정**: `router.replace()` 에 `{ scroll: false }` 추가 — 필터 클릭 시 스크롤 위치 유지
- **skeleton 깜빡임 수정**: `useJobPostings`에 `placeholderData: keepPreviousData` 적용 — 필터 변경 시 이전 결과 유지하다 새 데이터로 전환
- **`parseFitLevel` 중복 제거**: `page.tsx` / `useJobFilter.ts` / `route.ts` 3곳에 흩어진 동일 함수 → `features/dashboard/utils/parseFitLevel.ts` 하나로 통합
- **skeleton 개수 통일**: `JobListSkeleton` / `JobListSection` 모두 하드코딩 `6` → `JOB_POSTINGS_PAGE_SIZE`(12) 상수 참조
- **fitLevel '전체' 버튼 제거**: 선택된 버튼 재클릭으로 해제 가능하므로 불필요한 버튼 삭제

Closes #178