### PR TITLE
fix: 필터 변경 성능 개선 — 서버-클라이언트 이중 fetch 제거 #180

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,17 +7,7 @@ import { getDashboardData } from '@/features/dashboard/api/dashboardServerApi';
 import { LandingPage } from '@/features/landing';
 import { toPersonalityAxes, toMatchedJobs } from '@/shared/utils/matchConvert';
 import { TEST_PROFILE, TEST_MATCH } from '@/shared/constants/testUser';
-import { parseFitLevel } from '@/features/dashboard/utils/parseFitLevel';
-
-export default async function Home({
-  searchParams,
-}: {
-  searchParams: Promise<{ sigungu?: string; fitLevel?: string }>;
-}) {
-  const params = await searchParams;
-  const sigungu = params.sigungu ?? null;
-  const fitLevel = parseFitLevel(params.fitLevel);
-
+export default async function Home() {
   const session = await getServerSession();
 
   if (session) {
@@ -51,8 +41,6 @@ export default async function Home({
                 <JobListPrefetcher
                   userId={session.userId}
                   userName={profile.name}
-                  sigungu={sigungu}
-                  fitLevel={fitLevel}
                 />
               </Suspense>
             </section>

--- a/src/features/dashboard/JobListClient.tsx
+++ b/src/features/dashboard/JobListClient.tsx
@@ -22,8 +22,14 @@ export function JobListClient({ userName }: JobListClientProps) {
   const { sigungu, fitLevel, handleSelectSigungu, handleSelectFitLevel } =
     useJobFilter();
 
-  const { data, isPending, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useJobPostings({ sigungu, fitLevel });
+  const {
+    data,
+    isPending,
+    isPlaceholderData,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useJobPostings({ sigungu, fitLevel });
 
   const postings = useMemo(
     () => data?.pages.flatMap((page) => page.items) ?? [],
@@ -40,6 +46,7 @@ export function JobListClient({ userName }: JobListClientProps) {
     <>
       <JobListSection
         isLoading={isPending}
+        isFiltering={isPlaceholderData}
         userName={userName}
         postings={postings}
         onBookmarkToggle={handleBookmarkToggle}

--- a/src/features/dashboard/ui/JobListPrefetcher.tsx
+++ b/src/features/dashboard/ui/JobListPrefetcher.tsx
@@ -11,23 +11,15 @@ import {
 import { JOB_POSTINGS_PAGE_SIZE } from '../constants/jobPostingsConfig';
 import { QUERY_KEYS } from '@/shared/constants/queryKeys';
 import { JobListClient } from '../JobListClient';
-import type { FitLevel } from '@/shared/types/job';
 
 type Props = {
   userId: string;
   userName: string;
-  sigungu?: string | null;
-  fitLevel?: FitLevel | null;
 };
 
-export async function JobListPrefetcher({
-  userId,
-  userName,
-  sigungu = null,
-  fitLevel = null,
-}: Props) {
+export async function JobListPrefetcher({ userId, userName }: Props) {
   const queryClient = new QueryClient();
-  const filters = { sigungu, fitLevel };
+  const filters = { sigungu: null, fitLevel: null };
 
   await Promise.all([
     queryClient.prefetchInfiniteQuery({
@@ -36,8 +28,8 @@ export async function JobListPrefetcher({
         getJobPostingsPage(userId, {
           cursor: 0,
           limit: JOB_POSTINGS_PAGE_SIZE,
-          sigungu,
-          fitLevel,
+          sigungu: null,
+          fitLevel: null,
         }),
       initialPageParam: 0,
     }),

--- a/src/features/dashboard/ui/JobListSection.tsx
+++ b/src/features/dashboard/ui/JobListSection.tsx
@@ -12,6 +12,7 @@ type JobListSectionProps = {
   onBookmarkToggle: (job: JobPosting) => void;
   isLoading?: boolean;
   isLoadingUser?: boolean;
+  isFiltering?: boolean;
   sigunguList?: string[];
   selectedSigungu?: string | null;
   onSelectSigungu?: (sigungu: string | null) => void;
@@ -29,6 +30,7 @@ export function JobListSection({
   onBookmarkToggle,
   isLoading = false,
   isLoadingUser = false,
+  isFiltering = false,
   sigunguList = [],
   selectedSigungu = null,
   onSelectSigungu,
@@ -112,13 +114,22 @@ export function JobListSection({
           </p>
         </div>
       ) : (
-        <VirtualJobList
-          items={postings}
-          onBookmarkToggle={onBookmarkToggle}
-          hasNextPage={hasNextPage}
-          isFetchingNextPage={isFetchingNextPage}
-          fetchNextPage={onLoadMore}
-        />
+        <div
+          className={
+            isFiltering
+              ? 'pointer-events-none opacity-50 transition-opacity'
+              : undefined
+          }
+          aria-busy={isFiltering}
+        >
+          <VirtualJobList
+            items={postings}
+            onBookmarkToggle={onBookmarkToggle}
+            hasNextPage={hasNextPage}
+            isFetchingNextPage={isFetchingNextPage}
+            fetchNextPage={onLoadMore}
+          />
+        </div>
       )}
     </section>
   );

--- a/src/features/dashboard/ui/JobListSection.tsx
+++ b/src/features/dashboard/ui/JobListSection.tsx
@@ -117,8 +117,8 @@ export function JobListSection({
         <div
           className={
             isFiltering
-              ? 'pointer-events-none opacity-50 transition-opacity'
-              : undefined
+              ? 'pointer-events-none opacity-50 transition-opacity duration-200'
+              : 'transition-opacity duration-200'
           }
           aria-busy={isFiltering}
         >


### PR DESCRIPTION
## 개요
필터 변경 시 서버·클라이언트가 동시에 같은 데이터를 fetch하는 이중 fetch 문제를 제거해 필터 응답 속도를 개선함

## 주요 변경 사항
- **`JobListPrefetcher`에서 filter props 제거**: 항상 `{ sigungu: null, fitLevel: null }`로 SSR prefetch — `unstable_cache` 캐시 히트만 처리
- **`page.tsx`에서 `searchParams` filter 제거**: 서버 컴포넌트가 필터 상태를 읽지 않음 → 필터 변경 시 서버 재실행 영향 최소화
- **`isFiltering` 로딩 표시**: 필터 전환 중 `isPlaceholderData` → 카드 영역 `opacity-50 pointer-events-none` 으로 진행 중임을 표시

## 개선 흐름
```
[이전] 필터 클릭 → 서버 재실행 + 클라이언트 BFF 호출 (이중 fetch)
[이후] 필터 클릭 → 클라이언트 BFF 호출만 (unstable_cache 히트 시 ~20ms)
```

Closes #180