### PR TITLE
fix: ranked 결과 userId별 서버 캐싱으로 필터 성능 개선 #183

### DIFF
--- a/src/features/dashboard/api/jobPostingsServerApi.ts
+++ b/src/features/dashboard/api/jobPostingsServerApi.ts
@@ -65,26 +65,34 @@ const getCachedRawItems = unstable_cache(
   { revalidate: 300 },
 );
 
+const getCachedRankedPostings = unstable_cache(
+  async (userId: string): Promise<JobPosting[]> => {
+    const isTest = userId === TEST_USER_ID;
+
+    const [items, profileRows, bookmarkRows] = await Promise.all([
+      getCachedRawItems(),
+      isTest
+        ? Promise.resolve<ProfileRow[]>([TEST_PROFILE as unknown as ProfileRow])
+        : supabaseFetch<ProfileRow[]>(
+            `/rest/v1/profiles?user_id=eq.${userId}&select=mobility,hand_usage,stamina,communication,region_primary`,
+          ),
+      isTest
+        ? Promise.resolve<{ posting_url: string }[]>([])
+        : supabaseFetch<{ posting_url: string }[]>(
+            `/rest/v1/bookmarks?user_id=eq.${userId}&select=posting_url`,
+          ),
+    ]);
+
+    const profile = profileRows[0];
+    const bookmarkedUrls = new Set(bookmarkRows.map((r) => r.posting_url));
+    return rankPostings(items, profile, bookmarkedUrls);
+  },
+  ['ranked-postings'],
+  { revalidate: 300 },
+);
+
 export async function getRankedPostings(userId: string): Promise<JobPosting[]> {
-  const isTest = userId === TEST_USER_ID;
-
-  const [items, profileRows, bookmarkRows] = await Promise.all([
-    getCachedRawItems(),
-    isTest
-      ? Promise.resolve<ProfileRow[]>([TEST_PROFILE as unknown as ProfileRow])
-      : supabaseFetch<ProfileRow[]>(
-          `/rest/v1/profiles?user_id=eq.${userId}&select=mobility,hand_usage,stamina,communication,region_primary`,
-        ),
-    isTest
-      ? Promise.resolve<{ posting_url: string }[]>([])
-      : supabaseFetch<{ posting_url: string }[]>(
-          `/rest/v1/bookmarks?user_id=eq.${userId}&select=posting_url`,
-        ),
-  ]);
-
-  const profile = profileRows[0];
-  const bookmarkedUrls = new Set(bookmarkRows.map((r) => r.posting_url));
-  return rankPostings(items, profile, bookmarkedUrls);
+  return getCachedRankedPostings(userId);
 }
 
 export async function getJobPostingsPage(

--- a/src/features/dashboard/hooks/useJobFilter.ts
+++ b/src/features/dashboard/hooks/useJobFilter.ts
@@ -1,12 +1,11 @@
 'use client';
 
 import { useCallback } from 'react';
-import { useRouter, useSearchParams, usePathname } from 'next/navigation';
+import { useSearchParams, usePathname } from 'next/navigation';
 import type { FitLevel } from '@/shared/types/job';
 import { parseFitLevel } from '../utils/parseFitLevel';
 
 export function useJobFilter() {
-  const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
@@ -27,9 +26,13 @@ export function useJobFilter() {
       }
 
       const qs = params.toString();
-      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+      window.history.replaceState(
+        null,
+        '',
+        qs ? `${pathname}?${qs}` : pathname,
+      );
     },
-    [router, pathname, searchParams],
+    [pathname, searchParams],
   );
 
   const handleSelectSigungu = useCallback(

--- a/src/features/dashboard/hooks/useJobFilter.ts
+++ b/src/features/dashboard/hooks/useJobFilter.ts
@@ -1,11 +1,12 @@
 'use client';
 
 import { useCallback } from 'react';
-import { useSearchParams, usePathname } from 'next/navigation';
+import { useRouter, useSearchParams, usePathname } from 'next/navigation';
 import type { FitLevel } from '@/shared/types/job';
 import { parseFitLevel } from '../utils/parseFitLevel';
 
 export function useJobFilter() {
+  const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
@@ -26,13 +27,9 @@ export function useJobFilter() {
       }
 
       const qs = params.toString();
-      window.history.replaceState(
-        null,
-        '',
-        qs ? `${pathname}?${qs}` : pathname,
-      );
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
     },
-    [pathname, searchParams],
+    [router, pathname, searchParams],
   );
 
   const handleSelectSigungu = useCallback(


### PR DESCRIPTION
## 개요
필터 클릭 시마다 반복 실행되던 Supabase 조회 + ranking 연산을 userId별로 서버 캐싱하여 필터 성능 개선.

## 주요 변경 사항
- `getRankedPostings` 내부 로직을 `getCachedRankedPostings`로 분리
- `unstable_cache`로 userId별 ranked 전체 목록을 5분 캐싱
- 외부 공고 캐시(`getCachedRawItems`, 5분)와 동일한 revalidate 주기로 통일

## 변경 전 / 후
- **변경 전**: 매 필터 요청마다 Supabase profile 조회 + bookmarks 조회 + ranking 연산 실행
- **변경 후**: 첫 요청에서 캐시 워밍 → 이후 필터 요청은 캐시 반환 후 filter/slice만 실행

Closes #183