### PR TITLE
fix: 필터 낙관적 업데이트 및 일관된 스켈레톤 전환 #185

### DIFF
--- a/src/features/dashboard/JobListClient.tsx
+++ b/src/features/dashboard/JobListClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState, useEffect, useCallback, useRef } from 'react';
 
 import { ConfirmModal } from '@/shared/ui/ConfirmModal';
 import { ROUTES } from '@/shared/constants/routes';
@@ -9,6 +9,7 @@ import { useJobFilterOptions } from './hooks/useJobFilterOptions';
 import { useJobFilter } from './hooks/useJobFilter';
 import { useJobPostings } from './hooks/useJobPostings';
 import { JobListSection } from './ui/JobListSection';
+import type { FitLevel } from '@/shared/types/job';
 
 type JobListClientProps = {
   userName: string;
@@ -22,19 +23,63 @@ export function JobListClient({ userName }: JobListClientProps) {
   const { sigungu, fitLevel, handleSelectSigungu, handleSelectFitLevel } =
     useJobFilter();
 
+  const [isFiltering, setIsFiltering] = useState(false);
+  const filterStartTimeRef = useRef<number | null>(null);
+
   const {
     data,
     isPending,
-    isPlaceholderData,
+    isFetching,
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
   } = useJobPostings({ sigungu, fitLevel });
 
+  // 페칭 완료 시점에 클릭 후 500ms가 지났으면 즉시, 안 지났으면 남은 시간 후 스켈레톤 해제
+  useEffect(() => {
+    if (isFiltering && !isFetching && !isPending) {
+      const elapsed = filterStartTimeRef.current
+        ? Date.now() - filterStartTimeRef.current
+        : 500;
+      const remaining = Math.max(0, 500 - elapsed);
+      const timer = setTimeout(() => {
+        setIsFiltering(false);
+        filterStartTimeRef.current = null;
+      }, remaining);
+      return () => clearTimeout(timer);
+    }
+  }, [isFiltering, isFetching, isPending]);
+
+  const handleFilterSigungu = useCallback(
+    (value: string | null) => {
+      filterStartTimeRef.current = Date.now();
+      setIsFiltering(true);
+      handleSelectSigungu(value);
+    },
+    [handleSelectSigungu],
+  );
+
+  const handleFilterFitLevel = useCallback(
+    (value: FitLevel | null) => {
+      filterStartTimeRef.current = Date.now();
+      setIsFiltering(true);
+      handleSelectFitLevel(value);
+    },
+    [handleSelectFitLevel],
+  );
+
   const postings = useMemo(
     () => data?.pages.flatMap((page) => page.items) ?? [],
     [data],
   );
+
+  const [displayedPostings, setDisplayedPostings] = useState(postings);
+
+  useEffect(() => {
+    if (!isFiltering) {
+      setDisplayedPostings(postings);
+    }
+  }, [isFiltering, postings]);
 
   const {
     toggle: handleBookmarkToggle,
@@ -46,16 +91,16 @@ export function JobListClient({ userName }: JobListClientProps) {
     <>
       <JobListSection
         isLoading={isPending}
-        isFiltering={isPlaceholderData}
+        isFiltering={isFiltering}
         userName={userName}
-        postings={postings}
+        postings={displayedPostings}
         onBookmarkToggle={handleBookmarkToggle}
         sigunguList={sigunguList}
         selectedSigungu={sigungu}
-        onSelectSigungu={handleSelectSigungu}
+        onSelectSigungu={handleFilterSigungu}
         fitLevelList={fitLevelList}
         selectedFitLevel={fitLevel}
-        onSelectFitLevel={handleSelectFitLevel}
+        onSelectFitLevel={handleFilterFitLevel}
         hasNextPage={hasNextPage}
         isFetchingNextPage={isFetchingNextPage}
         onLoadMore={fetchNextPage}

--- a/src/features/dashboard/hooks/useJobFilter.ts
+++ b/src/features/dashboard/hooks/useJobFilter.ts
@@ -1,49 +1,58 @@
 'use client';
 
-import { useCallback } from 'react';
-import { useRouter, useSearchParams, usePathname } from 'next/navigation';
+import { useState, useEffect, useCallback } from 'react';
+import { useSearchParams, usePathname } from 'next/navigation';
 import type { FitLevel } from '@/shared/types/job';
 import { parseFitLevel } from '../utils/parseFitLevel';
 
 export function useJobFilter() {
-  const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const sigungu = searchParams.get('sigungu') || null;
-  const fitLevel = parseFitLevel(searchParams.get('fitLevel'));
+  const [sigungu, setSigungu] = useState<string | null>(
+    searchParams.get('sigungu') || null,
+  );
+  const [fitLevel, setFitLevel] = useState<FitLevel | null>(
+    parseFitLevel(searchParams.get('fitLevel')),
+  );
 
-  const updateParams = useCallback(
-    (updates: { sigungu?: string | null; fitLevel?: FitLevel | null }) => {
-      const params = new URLSearchParams(searchParams.toString());
+  // 뒤로가기/앞으로가기 시 URL과 동기화
+  useEffect(() => {
+    setSigungu(searchParams.get('sigungu') || null);
+    setFitLevel(parseFitLevel(searchParams.get('fitLevel')));
+  }, [searchParams]);
 
-      if ('sigungu' in updates) {
-        if (updates.sigungu) params.set('sigungu', updates.sigungu);
-        else params.delete('sigungu');
-      }
-      if ('fitLevel' in updates) {
-        if (updates.fitLevel) params.set('fitLevel', updates.fitLevel);
-        else params.delete('fitLevel');
-      }
-
+  const updateUrl = useCallback(
+    (newSigungu: string | null, newFitLevel: FitLevel | null) => {
+      const params = new URLSearchParams();
+      if (newSigungu) params.set('sigungu', newSigungu);
+      if (newFitLevel) params.set('fitLevel', newFitLevel);
       const qs = params.toString();
-      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+      window.history.replaceState(
+        null,
+        '',
+        qs ? `${pathname}?${qs}` : pathname,
+      );
     },
-    [router, pathname, searchParams],
+    [pathname],
   );
 
   const handleSelectSigungu = useCallback(
     (value: string | null) => {
-      updateParams({ sigungu: sigungu === value ? null : value });
+      const newValue = sigungu === value ? null : value;
+      setSigungu(newValue);
+      updateUrl(newValue, fitLevel);
     },
-    [sigungu, updateParams],
+    [sigungu, fitLevel, updateUrl],
   );
 
   const handleSelectFitLevel = useCallback(
     (value: FitLevel | null) => {
-      updateParams({ fitLevel: fitLevel === value ? null : value });
+      const newValue = fitLevel === value ? null : value;
+      setFitLevel(newValue);
+      updateUrl(sigungu, newValue);
     },
-    [fitLevel, updateParams],
+    [fitLevel, sigungu, updateUrl],
   );
 
   return { sigungu, fitLevel, handleSelectSigungu, handleSelectFitLevel };

--- a/src/features/dashboard/hooks/useJobFilter.ts
+++ b/src/features/dashboard/hooks/useJobFilter.ts
@@ -1,26 +1,41 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { useSearchParams, usePathname } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import type { FitLevel } from '@/shared/types/job';
 import { parseFitLevel } from '../utils/parseFitLevel';
 
+function readFiltersFromUrl() {
+  const params = new URLSearchParams(window.location.search);
+  return {
+    sigungu: params.get('sigungu') || null,
+    fitLevel: parseFitLevel(params.get('fitLevel')),
+  };
+}
+
 export function useJobFilter() {
   const pathname = usePathname();
-  const searchParams = useSearchParams();
 
-  const [sigungu, setSigungu] = useState<string | null>(
-    searchParams.get('sigungu') || null,
-  );
-  const [fitLevel, setFitLevel] = useState<FitLevel | null>(
-    parseFitLevel(searchParams.get('fitLevel')),
-  );
+  const [sigungu, setSigungu] = useState<string | null>(null);
+  const [fitLevel, setFitLevel] = useState<FitLevel | null>(null);
+
+  // 마운트 시 URL에서 초기값 읽기
+  useEffect(() => {
+    const { sigungu: s, fitLevel: f } = readFiltersFromUrl();
+    setSigungu(s);
+    setFitLevel(f);
+  }, []);
 
   // 뒤로가기/앞으로가기 시 URL과 동기화
   useEffect(() => {
-    setSigungu(searchParams.get('sigungu') || null);
-    setFitLevel(parseFitLevel(searchParams.get('fitLevel')));
-  }, [searchParams]);
+    const handlePopState = () => {
+      const { sigungu: s, fitLevel: f } = readFiltersFromUrl();
+      setSigungu(s);
+      setFitLevel(f);
+    };
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, []);
 
   const updateUrl = useCallback(
     (newSigungu: string | null, newFitLevel: FitLevel | null) => {

--- a/src/features/dashboard/hooks/useJobFilter.ts
+++ b/src/features/dashboard/hooks/useJobFilter.ts
@@ -1,41 +1,26 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { usePathname } from 'next/navigation';
+import { useSearchParams, usePathname } from 'next/navigation';
 import type { FitLevel } from '@/shared/types/job';
 import { parseFitLevel } from '../utils/parseFitLevel';
 
-function readFiltersFromUrl() {
-  const params = new URLSearchParams(window.location.search);
-  return {
-    sigungu: params.get('sigungu') || null,
-    fitLevel: parseFitLevel(params.get('fitLevel')),
-  };
-}
-
 export function useJobFilter() {
   const pathname = usePathname();
+  const searchParams = useSearchParams();
 
-  const [sigungu, setSigungu] = useState<string | null>(null);
-  const [fitLevel, setFitLevel] = useState<FitLevel | null>(null);
-
-  // 마운트 시 URL에서 초기값 읽기
-  useEffect(() => {
-    const { sigungu: s, fitLevel: f } = readFiltersFromUrl();
-    setSigungu(s);
-    setFitLevel(f);
-  }, []);
+  const [sigungu, setSigungu] = useState<string | null>(
+    searchParams.get('sigungu') || null,
+  );
+  const [fitLevel, setFitLevel] = useState<FitLevel | null>(
+    parseFitLevel(searchParams.get('fitLevel')),
+  );
 
   // 뒤로가기/앞으로가기 시 URL과 동기화
   useEffect(() => {
-    const handlePopState = () => {
-      const { sigungu: s, fitLevel: f } = readFiltersFromUrl();
-      setSigungu(s);
-      setFitLevel(f);
-    };
-    window.addEventListener('popstate', handlePopState);
-    return () => window.removeEventListener('popstate', handlePopState);
-  }, []);
+    setSigungu(searchParams.get('sigungu') || null);
+    setFitLevel(parseFitLevel(searchParams.get('fitLevel')));
+  }, [searchParams]);
 
   const updateUrl = useCallback(
     (newSigungu: string | null, newFitLevel: FitLevel | null) => {

--- a/src/features/dashboard/ui/JobListSection.tsx
+++ b/src/features/dashboard/ui/JobListSection.tsx
@@ -83,6 +83,7 @@ export function JobListSection({
           fitLevelList={fitLevelList}
           selectedFitLevel={selectedFitLevel}
           onSelectFitLevel={onSelectFitLevel}
+          disabled={isFiltering}
         />
       ) : null}
 

--- a/src/features/dashboard/ui/JobListSection.tsx
+++ b/src/features/dashboard/ui/JobListSection.tsx
@@ -104,15 +104,6 @@ export function JobListSection({
             </li>
           ))}
         </ul>
-      ) : showEmpty ? (
-        <div className="flex flex-col items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 py-16 text-center">
-          <p className="text-[0.9375rem] font-semibold text-gray-700">
-            희망 지역의 채용공고가 없어요
-          </p>
-          <p className="text-[0.875rem] text-gray-400">
-            프로필에서 희망 지역을 변경하거나 나중에 다시 확인해보세요
-          </p>
-        </div>
       ) : (
         <div
           className={
@@ -122,13 +113,24 @@ export function JobListSection({
           }
           aria-busy={isFiltering}
         >
-          <VirtualJobList
-            items={postings}
-            onBookmarkToggle={onBookmarkToggle}
-            hasNextPage={hasNextPage}
-            isFetchingNextPage={isFetchingNextPage}
-            fetchNextPage={onLoadMore}
-          />
+          {showEmpty ? (
+            <div className="flex flex-col items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 py-16 text-center">
+              <p className="text-[0.9375rem] font-semibold text-gray-700">
+                희망 지역의 채용공고가 없어요
+              </p>
+              <p className="text-[0.875rem] text-gray-400">
+                프로필에서 희망 지역을 변경하거나 나중에 다시 확인해보세요
+              </p>
+            </div>
+          ) : (
+            <VirtualJobList
+              items={postings}
+              onBookmarkToggle={onBookmarkToggle}
+              hasNextPage={hasNextPage}
+              isFetchingNextPage={isFetchingNextPage}
+              fetchNextPage={onLoadMore}
+            />
+          )}
         </div>
       )}
     </section>

--- a/src/features/dashboard/ui/JobRegionFilter.tsx
+++ b/src/features/dashboard/ui/JobRegionFilter.tsx
@@ -15,6 +15,7 @@ type JobRegionFilterProps = {
   fitLevelList: FitLevel[];
   selectedFitLevel: FitLevel | null;
   onSelectFitLevel: (fitLevel: FitLevel | null) => void;
+  disabled?: boolean;
 };
 
 export function JobRegionFilter({
@@ -24,6 +25,7 @@ export function JobRegionFilter({
   fitLevelList,
   selectedFitLevel,
   onSelectFitLevel,
+  disabled = false,
 }: JobRegionFilterProps) {
   if (sigunguList.length === 0 && fitLevelList.length < 2) return null;
 
@@ -49,8 +51,10 @@ export function JobRegionFilter({
             type="button"
             aria-pressed={selectedSigungu === null}
             onClick={() => onSelectSigungu(null)}
+            disabled={disabled}
             className={cn(
-              'h-8 cursor-pointer rounded-sm border px-3 text-[0.8125rem] font-semibold transition-colors',
+              'h-8 rounded-sm border px-3 text-[0.8125rem] font-semibold transition-colors',
+              disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
               selectedSigungu === null
                 ? 'border-primary bg-primary-tag text-primary'
                 : 'border-gray-200 bg-white text-gray-700 hover:border-gray-300 hover:bg-gray-50',
@@ -67,8 +71,10 @@ export function JobRegionFilter({
               type="button"
               aria-pressed={selectedSigungu === sigungu}
               onClick={() => onSelectSigungu(sigungu)}
+              disabled={disabled}
               className={cn(
-                'h-8 cursor-pointer rounded-sm border px-3 text-[0.8125rem] font-semibold transition-colors',
+                'h-8 rounded-sm border px-3 text-[0.8125rem] font-semibold transition-colors',
+                disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
                 selectedSigungu === sigungu
                   ? 'border-primary bg-primary-tag text-primary'
                   : 'border-gray-200 bg-white text-gray-700 hover:border-gray-300 hover:bg-gray-50',
@@ -92,8 +98,10 @@ export function JobRegionFilter({
               type="button"
               aria-pressed={selectedFitLevel === fitLevel}
               onClick={() => onSelectFitLevel(fitLevel)}
+              disabled={disabled}
               className={cn(
-                'h-8 cursor-pointer rounded-sm border px-3 text-[0.8125rem] font-semibold transition-colors',
+                'h-8 rounded-sm border px-3 text-[0.8125rem] font-semibold transition-colors',
+                disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
                 selectedFitLevel === fitLevel
                   ? fitLevelSelectedStyle[fitLevel]
                   : 'border-gray-200 bg-white text-gray-700 hover:border-gray-300 hover:bg-gray-50',


### PR DESCRIPTION
## 개요
필터 클릭 시 RSC 요청 제거, 낙관적 업데이트, 캐싱/비캐싱 일관된 스켈레톤 전환 개선.

## 주요 변경 사항
- `useJobFilter`: `router.replace` → `window.history.replaceState` (RSC 요청 제거), 필터 상태를 React state로 관리해 클릭 즉시 버튼 반영
- `JobListClient`: `isFiltering` 직접 관리 — 클릭 시 즉시 켜고, 페칭 완료 후 최소 500ms 유지
- `displayedPostings` 도입 — 스켈레톤 중엔 이전 공고 유지, 전환 완료 후 새 공고로 교체

## 동작 흐름
필터 클릭 → 버튼 즉시 선택 상태 + 현재 공고 스켈레톤 → 페칭 완료 & 500ms 경과 → 스켈레톤 해제 + 새 공고 표시

Closes #185