### PR TITLE
fix: 필터 disabled 상태에서 hover 스타일 제거 #187

### DIFF
--- a/src/features/dashboard/ui/JobRegionFilter.tsx
+++ b/src/features/dashboard/ui/JobRegionFilter.tsx
@@ -57,7 +57,10 @@ export function JobRegionFilter({
               disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
               selectedSigungu === null
                 ? 'border-primary bg-primary-tag text-primary'
-                : 'border-gray-200 bg-white text-gray-700 hover:border-gray-300 hover:bg-gray-50',
+                : cn(
+                    'border-gray-200 bg-white text-gray-700',
+                    !disabled && 'hover:border-gray-300 hover:bg-gray-50',
+                  ),
             )}
           >
             전체
@@ -77,7 +80,10 @@ export function JobRegionFilter({
                 disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
                 selectedSigungu === sigungu
                   ? 'border-primary bg-primary-tag text-primary'
-                  : 'border-gray-200 bg-white text-gray-700 hover:border-gray-300 hover:bg-gray-50',
+                  : cn(
+                      'border-gray-200 bg-white text-gray-700',
+                      !disabled && 'hover:border-gray-300 hover:bg-gray-50',
+                    ),
               )}
             >
               {sigungu}
@@ -104,7 +110,10 @@ export function JobRegionFilter({
                 disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
                 selectedFitLevel === fitLevel
                   ? fitLevelSelectedStyle[fitLevel]
-                  : 'border-gray-200 bg-white text-gray-700 hover:border-gray-300 hover:bg-gray-50',
+                  : cn(
+                      'border-gray-200 bg-white text-gray-700',
+                      !disabled && 'hover:border-gray-300 hover:bg-gray-50',
+                    ),
               )}
             >
               {fitLevel}


### PR DESCRIPTION
## 개요
공고 로딩 중 필터 버튼에 `disabled` 속성이 있어도 CSS `:hover`가 동작해 hover 스타일이 노출되던 문제를 수정.

## 주요 변경 사항
- `JobRegionFilter`의 전체·시군구·적합도 버튼 세 곳 모두, 비선택 상태의 hover 클래스(`hover:border-gray-300 hover:bg-gray-50`)를 `!disabled`일 때만 적용하도록 변경

Closes #187