### PR TITLE
feat: button xs size 추가 및 JobRegionFilter button 마이그레이션 #189

### DIFF
--- a/src/features/dashboard/ui/JobRegionFilter.tsx
+++ b/src/features/dashboard/ui/JobRegionFilter.tsx
@@ -3,6 +3,9 @@ import type { FitLevel } from '@/shared/types/job';
 import { Button } from '@/shared/ui/Button/Button';
 import { cn } from '@/shared/utils/cn';
 
+const SIGUNGU_SELECTED_STYLE =
+  'border-primary bg-primary-tag text-primary enabled:hover:bg-primary-tag';
+
 const fitLevelSelectedStyle: Record<FitLevel, string> = {
   '잘 맞아요':
     'border-success bg-success-bg text-success enabled:hover:bg-success-bg',
@@ -57,10 +60,7 @@ export function JobRegionFilter({
             aria-pressed={selectedSigungu === null}
             onClick={() => onSelectSigungu(null)}
             disabled={disabled}
-            className={cn(
-              selectedSigungu === null &&
-                'border-primary bg-primary-tag text-primary enabled:hover:bg-primary-tag',
-            )}
+            className={cn(selectedSigungu === null && SIGUNGU_SELECTED_STYLE)}
           >
             전체
           </Button>
@@ -76,8 +76,7 @@ export function JobRegionFilter({
               onClick={() => onSelectSigungu(sigungu)}
               disabled={disabled}
               className={cn(
-                selectedSigungu === sigungu &&
-                  'border-primary bg-primary-tag text-primary enabled:hover:bg-primary-tag',
+                selectedSigungu === sigungu && SIGUNGU_SELECTED_STYLE,
               )}
             >
               {sigungu}

--- a/src/features/dashboard/ui/JobRegionFilter.tsx
+++ b/src/features/dashboard/ui/JobRegionFilter.tsx
@@ -1,11 +1,15 @@
 import { Info } from 'lucide-react';
 import type { FitLevel } from '@/shared/types/job';
+import { Button } from '@/shared/ui/Button/Button';
 import { cn } from '@/shared/utils/cn';
 
 const fitLevelSelectedStyle: Record<FitLevel, string> = {
-  '잘 맞아요': 'border-success bg-success-bg text-success',
-  '도전해볼 수 있어요': 'border-warning bg-warning-bg text-warning',
-  '힘들 수 있어요': 'border-error bg-error-bg text-error',
+  '잘 맞아요':
+    'border-success bg-success-bg text-success enabled:hover:bg-success-bg',
+  '도전해볼 수 있어요':
+    'border-warning bg-warning-bg text-warning enabled:hover:bg-warning-bg',
+  '힘들 수 있어요':
+    'border-error bg-error-bg text-error enabled:hover:bg-error-bg',
 };
 
 type JobRegionFilterProps = {
@@ -47,47 +51,37 @@ export function JobRegionFilter({
           aria-label="시/군/구 필터"
           className="mb-2 flex flex-wrap gap-2"
         >
-          <button
-            type="button"
+          <Button
+            variant="outline"
+            size="xs"
             aria-pressed={selectedSigungu === null}
             onClick={() => onSelectSigungu(null)}
             disabled={disabled}
             className={cn(
-              'h-8 rounded-sm border px-3 text-[0.8125rem] font-semibold transition-colors',
-              disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
-              selectedSigungu === null
-                ? 'border-primary bg-primary-tag text-primary'
-                : cn(
-                    'border-gray-200 bg-white text-gray-700',
-                    !disabled && 'hover:border-gray-300 hover:bg-gray-50',
-                  ),
+              selectedSigungu === null &&
+                'border-primary bg-primary-tag text-primary enabled:hover:bg-primary-tag',
             )}
           >
             전체
-          </button>
+          </Button>
 
           <div aria-hidden="true" className="w-px self-stretch bg-gray-300" />
 
           {sigunguList.map((sigungu) => (
-            <button
+            <Button
               key={sigungu}
-              type="button"
+              variant="outline"
+              size="xs"
               aria-pressed={selectedSigungu === sigungu}
               onClick={() => onSelectSigungu(sigungu)}
               disabled={disabled}
               className={cn(
-                'h-8 rounded-sm border px-3 text-[0.8125rem] font-semibold transition-colors',
-                disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
-                selectedSigungu === sigungu
-                  ? 'border-primary bg-primary-tag text-primary'
-                  : cn(
-                      'border-gray-200 bg-white text-gray-700',
-                      !disabled && 'hover:border-gray-300 hover:bg-gray-50',
-                    ),
+                selectedSigungu === sigungu &&
+                  'border-primary bg-primary-tag text-primary enabled:hover:bg-primary-tag',
               )}
             >
               {sigungu}
-            </button>
+            </Button>
           ))}
         </div>
       )}
@@ -99,25 +93,20 @@ export function JobRegionFilter({
           className="mb-8 flex flex-wrap gap-2"
         >
           {fitLevelList.map((fitLevel) => (
-            <button
+            <Button
               key={fitLevel}
-              type="button"
+              variant="outline"
+              size="xs"
               aria-pressed={selectedFitLevel === fitLevel}
               onClick={() => onSelectFitLevel(fitLevel)}
               disabled={disabled}
               className={cn(
-                'h-8 rounded-sm border px-3 text-[0.8125rem] font-semibold transition-colors',
-                disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
-                selectedFitLevel === fitLevel
-                  ? fitLevelSelectedStyle[fitLevel]
-                  : cn(
-                      'border-gray-200 bg-white text-gray-700',
-                      !disabled && 'hover:border-gray-300 hover:bg-gray-50',
-                    ),
+                selectedFitLevel === fitLevel &&
+                  fitLevelSelectedStyle[fitLevel],
               )}
             >
               {fitLevel}
-            </button>
+            </Button>
           ))}
         </div>
       )}

--- a/src/features/dashboard/ui/JobRegionFilter.tsx
+++ b/src/features/dashboard/ui/JobRegionFilter.tsx
@@ -1,19 +1,27 @@
+import { cva } from 'class-variance-authority';
 import { Info } from 'lucide-react';
 import type { FitLevel } from '@/shared/types/job';
 import { Button } from '@/shared/ui/Button/Button';
-import { cn } from '@/shared/utils/cn';
 
-const SIGUNGU_SELECTED_STYLE =
-  'border-primary bg-primary-tag text-primary enabled:hover:bg-primary-tag';
+const filterChipVariants = cva('', {
+  variants: {
+    selected: {
+      sigungu:
+        'border-primary bg-primary-tag text-primary enabled:hover:bg-primary-tag',
+      success:
+        'border-success bg-success-bg text-success enabled:hover:bg-success-bg',
+      warning:
+        'border-warning bg-warning-bg text-warning enabled:hover:bg-warning-bg',
+      error: 'border-error bg-error-bg text-error enabled:hover:bg-error-bg',
+    },
+  },
+});
 
-const fitLevelSelectedStyle: Record<FitLevel, string> = {
-  '잘 맞아요':
-    'border-success bg-success-bg text-success enabled:hover:bg-success-bg',
-  '도전해볼 수 있어요':
-    'border-warning bg-warning-bg text-warning enabled:hover:bg-warning-bg',
-  '힘들 수 있어요':
-    'border-error bg-error-bg text-error enabled:hover:bg-error-bg',
-};
+const fitLevelVariant = {
+  '잘 맞아요': 'success',
+  '도전해볼 수 있어요': 'warning',
+  '힘들 수 있어요': 'error',
+} as const satisfies Record<FitLevel, 'success' | 'warning' | 'error'>;
 
 type JobRegionFilterProps = {
   sigunguList: string[];
@@ -60,7 +68,9 @@ export function JobRegionFilter({
             aria-pressed={selectedSigungu === null}
             onClick={() => onSelectSigungu(null)}
             disabled={disabled}
-            className={cn(selectedSigungu === null && SIGUNGU_SELECTED_STYLE)}
+            className={filterChipVariants({
+              selected: selectedSigungu === null ? 'sigungu' : undefined,
+            })}
           >
             전체
           </Button>
@@ -75,9 +85,9 @@ export function JobRegionFilter({
               aria-pressed={selectedSigungu === sigungu}
               onClick={() => onSelectSigungu(sigungu)}
               disabled={disabled}
-              className={cn(
-                selectedSigungu === sigungu && SIGUNGU_SELECTED_STYLE,
-              )}
+              className={filterChipVariants({
+                selected: selectedSigungu === sigungu ? 'sigungu' : undefined,
+              })}
             >
               {sigungu}
             </Button>
@@ -99,10 +109,12 @@ export function JobRegionFilter({
               aria-pressed={selectedFitLevel === fitLevel}
               onClick={() => onSelectFitLevel(fitLevel)}
               disabled={disabled}
-              className={cn(
-                selectedFitLevel === fitLevel &&
-                  fitLevelSelectedStyle[fitLevel],
-              )}
+              className={filterChipVariants({
+                selected:
+                  selectedFitLevel === fitLevel
+                    ? fitLevelVariant[fitLevel]
+                    : undefined,
+              })}
             >
               {fitLevel}
             </Button>

--- a/src/shared/ui/Button/Button.tsx
+++ b/src/shared/ui/Button/Button.tsx
@@ -17,10 +17,12 @@ const buttonVariants = cva(
           'disabled:border-gray-200 disabled:bg-white disabled:text-gray-400',
         ghost:
           'border border-transparent bg-transparent text-gray-700 ' +
-          'hover:bg-gray-100',
+          'enabled:hover:bg-gray-100 ' +
+          'disabled:opacity-50',
         outline:
           'border border-gray-300 bg-white text-gray-700 ' +
-          'hover:bg-gray-100',
+          'enabled:hover:bg-gray-100 ' +
+          'disabled:opacity-50',
         destructive:
           'border border-transparent bg-error text-static-white ' +
           'hover:bg-error-hover',
@@ -32,6 +34,7 @@ const buttonVariants = cva(
         lg: 'h-12 px-5',
         md: 'h-[46px] px-4',
         sm: 'h-[42px] px-3',
+        xs: 'h-8 rounded-sm px-3 text-[0.8125rem]',
         icon: 'h-11 w-11',
       },
     },

--- a/src/shared/ui/Button/Button.tsx
+++ b/src/shared/ui/Button/Button.tsx
@@ -25,10 +25,12 @@ const buttonVariants = cva(
           'disabled:opacity-50',
         destructive:
           'border border-transparent bg-error text-static-white ' +
-          'hover:bg-error-hover',
+          'enabled:hover:bg-error-hover ' +
+          'disabled:opacity-50',
         kakao:
           'border border-transparent bg-[var(--kakao)] text-[var(--kakao-text)] ' +
-          'hover:bg-[var(--kakao-hover)]',
+          'enabled:hover:bg-[var(--kakao-hover)] ' +
+          'disabled:opacity-50',
       },
       size: {
         lg: 'h-12 px-5',


### PR DESCRIPTION
## 개요
Button 컴포넌트에 xs 사이즈를 신설하고, raw `<button>`을 직접 쓰던 JobRegionFilter를 Button 컴포넌트로 교체했습니다.

## 주요 변경 사항
- `Button` — `xs` 사이즈 추가: `h-8 rounded-sm px-3 text-[0.8125rem]`
- `Button` — `outline`/`ghost` variant에 `enabled:hover:` 적용 및 `disabled:opacity-50` 추가 (disabled 시 hover 차단)
- `JobRegionFilter` — raw `<button>` → `Button variant="outline" size="xs"` 교체
- 선택/비선택/disabled 상태별 hover 스타일 완전 동기화 (merged PR 스타일 유지)

Closes #189