### PR TITLE
refactor: 무한 스크롤 트리거를 index 기반 방식으로 전환 #193

### DIFF
--- a/src/features/dashboard/ui/VirtualJobList.tsx
+++ b/src/features/dashboard/ui/VirtualJobList.tsx
@@ -26,7 +26,6 @@ export function VirtualJobList({
 }: Props) {
   const columns = useBreakpointLimit();
   const listRef = useRef<HTMLDivElement>(null);
-  const sentinelRef = useRef<HTMLDivElement>(null);
   const [scrollMargin, setScrollMargin] = useState(0);
 
   useLayoutEffect(() => {
@@ -43,22 +42,20 @@ export function VirtualJobList({
     overscan: 2,
   });
 
-  // isFetchingNextPage 변화에도 observer를 재생성해 fetch 완료 후 sentinel이
-  // 여전히 뷰포트에 있으면 자동 재발화시킨다
-  useEffect(() => {
-    const sentinel = sentinelRef.current;
-    if (!sentinel || !fetchNextPage) return;
-    if (!hasNextPage || isFetchingNextPage) return;
+  const virtualItems = virtualizer.getVirtualItems();
+  const lastItem = virtualItems[virtualItems.length - 1];
 
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) fetchNextPage();
-      },
-      { threshold: 0 },
-    );
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+  useEffect(() => {
+    if (!lastItem || !fetchNextPage) return;
+    if (!hasNextPage || isFetchingNextPage) return;
+    if (lastItem.index >= rowCount - 1) fetchNextPage();
+  }, [
+    lastItem?.index,
+    rowCount,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  ]);
 
   const ariaSetSize = hasNextPage ? -1 : items.length;
 
@@ -109,17 +106,6 @@ export function VirtualJobList({
             </div>
           );
         })}
-
-        <div
-          ref={sentinelRef}
-          aria-hidden="true"
-          style={{
-            position: 'absolute',
-            bottom: 200,
-            height: 1,
-            width: '100%',
-          }}
-        />
       </div>
 
       {isFetchingNextPage && (


### PR DESCRIPTION
## 개요
`VirtualJobList`의 무한 스크롤 트리거를 sentinel div + IntersectionObserver 방식에서 TanStack Virtual의 index 기반 방식으로 교체

## 주요 변경 사항
- `sentinelRef`와 sentinel `<div>` 제거
- `IntersectionObserver` 생성·observe·disconnect 로직 제거
- `virtualizer.getVirtualItems()`의 마지막 항목 index가 `rowCount - 1`에 도달하면 `fetchNextPage` 호출하는 방식으로 전환
- `overscan: 2` 덕분에 실제 스크롤 끝에 도달하기 2행 전에 미리 fetch 발화

Closes #193