### PR TITLE
refactor: add throwOnError option to QueryClient defaults #195

### DIFF
--- a/src/shared/providers/query-provider.tsx
+++ b/src/shared/providers/query-provider.tsx
@@ -14,7 +14,16 @@ const ReactQueryDevtools =
     : () => null;
 
 export const QueryProvider = ({ children }: { children: ReactNode }) => {
-  const [queryClient] = useState(() => new QueryClient());
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            throwOnError: true,
+          },
+        },
+      }),
+  );
 
   return (
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
## 개요
QueryClient 전역 기본 옵션에 `throwOnError: true`를 추가하여 useQuery/useInfiniteQuery 실패 시 Error Boundary(error.tsx)로 에러가 자동 전파되도록 설정

## 주요 변경 사항
- `shared/providers/query-provider.tsx`: QueryClient 생성 시 `defaultOptions.queries.throwOnError: true` 추가
- 기존 `isError` 분기 처리 없는 쿼리에서 빈 화면 대신 error.tsx 에러 UI가 노출됨
- `useCurrentUser`는 queryFn 내부에서 에러를 catch하여 null 반환하므로 영향 없음

Closes #195