### PR TITLE
chore: add supabase keep-alive github actions workflow #211

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,18 @@
+name: Supabase Keep Alive
+
+on:
+  schedule:
+    - cron: '0 0 */5 * *' # 5일마다 자정 실행
+  workflow_dispatch: # 수동 실행 가능
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping Supabase
+        run: |
+          curl -sf \
+            "${{ secrets.SUPABASE_URL }}/rest/v1/users?select=count" \
+            -H "apikey: ${{ secrets.SUPABASE_SECRET_KEY }}" \
+            -H "Authorization: Bearer ${{ secrets.SUPABASE_SECRET_KEY }}" \
+            && echo "Supabase ping OK"


### PR DESCRIPTION
## 개요
Supabase 무료 플랜의 7일 비활성 자동 일시정지를 방지하기 위한 GitHub Actions 크론 워크플로우를 추가한다.

## 주요 변경 사항
- `.github/workflows/keep-alive.yml` 추가
- 5일마다(cron `0 0 */5 * *`) Supabase REST API에 ping 쿼리 자동 실행
- `workflow_dispatch`로 수동 즉시 실행 가능
- GitHub Secrets `SUPABASE_URL`, `SUPABASE_SECRET_KEY` 사용

## 사전 조건
GitHub 레포 → Settings → Secrets and variables → Actions에서 아래 두 시크릿 등록 필요:
- `SUPABASE_URL`
- `SUPABASE_SECRET_KEY`

Closes #211