### PR TITLE
chore: improve supabase keep-alive workflow and add health check #213

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -2,17 +2,27 @@ name: Supabase Keep Alive
 
 on:
   schedule:
-    - cron: '0 0 */5 * *' # 5일마다 자정 실행
-  workflow_dispatch: # 수동 실행 가능
+    - cron: '0 1 */3 * *' # 3일마다 10:00 KST (UTC 01:00)
+  workflow_dispatch:
 
 jobs:
   ping:
     runs-on: ubuntu-latest
     steps:
-      - name: Ping Supabase
+      - name: Check Supabase health
         run: |
-          curl -sf \
-            "${{ secrets.SUPABASE_URL }}/rest/v1/users?select=count" \
-            -H "apikey: ${{ secrets.SUPABASE_SECRET_KEY }}" \
-            -H "Authorization: Bearer ${{ secrets.SUPABASE_SECRET_KEY }}" \
+          STATUS=$(curl -sf -o /dev/null -w "%{http_code}" \
+            "${{ secrets.SUPABASE_URL }}/health")
+          echo "HTTP status: $STATUS"
+          if [ "$STATUS" != "200" ]; then
+            echo "Supabase health check FAILED (status: $STATUS)"
+            exit 1
+          fi
+          echo "Supabase is healthy"
+
+      - name: Ping via app
+        run: |
+          curl -fsS \
+            -H "x-ping-secret: ${{ secrets.PING_SECRET }}" \
+            "${{ secrets.NEXT_PUBLIC_SITE_URL }}/api/ping" \
             && echo "Supabase ping OK"

--- a/src/app/api/ping/route.ts
+++ b/src/app/api/ping/route.ts
@@ -3,12 +3,14 @@ import { supabaseFetch } from '@/shared/api/supabaseFetch';
 
 export const GET = async (req: Request) => {
   const secret = process.env.PING_SECRET;
-  if (secret && req.headers.get('x-ping-secret') !== secret) {
+  if (!secret || req.headers.get('x-ping-secret') !== secret) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   try {
-    await supabaseFetch('/rest/v1/users?select=count&limit=1');
+    await supabaseFetch('/rest/v1/users?select=count&limit=1', {
+      cache: 'no-store',
+    });
     return NextResponse.json({ ok: true });
   } catch {
     return NextResponse.json({ error: 'ping failed' }, { status: 500 });

--- a/src/app/api/ping/route.ts
+++ b/src/app/api/ping/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { supabaseFetch } from '@/shared/api/supabaseFetch';
+
+export const GET = async (req: Request) => {
+  const secret = process.env.PING_SECRET;
+  if (secret && req.headers.get('x-ping-secret') !== secret) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    await supabaseFetch('/rest/v1/users?select=count&limit=1');
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ error: 'ping failed' }, { status: 500 });
+  }
+};


### PR DESCRIPTION
## 개요

GitHub Actions에서 service role key로 Supabase를 직접 ping하는 기존 방식이 Supabase 비활성 타이머를 리셋하지 않아 자동 일시정지가 반복됐다. Vercel 앱을 경유하는 방식으로 전환하고, 헬스체크 스텝을 추가했다.

## 변경 파일

### `src/app/api/ping/route.ts` (신규)

- `x-ping-secret` 헤더 인증 — `PING_SECRET` 환경변수와 비교해 무단 호출 차단
- 인증 통과 후 기존 `supabaseFetch`로 DB 쿼리 실행
- `PING_SECRET` 미설정 시 인증 스킵 (로컬 개발 편의)

### `.github/workflows/keep-alive.yml`

| 항목 | 변경 전 | 변경 후 |
|------|---------|---------|
| 호출 대상 | Supabase REST API 직접 | Vercel 앱 `/api/ping` 경유 |
| 인증 방식 | `SUPABASE_SECRET_KEY` 헤더 직접 사용 | `PING_SECRET` 헤더 |
| 헬스체크 | 없음 | Supabase `/health` 엔드포인트 확인 (실패 시 중단) |
| 실행 주기 | 5일 (`*/5`) | 3일 (`*/3`) |

**주기 변경 이유**: 5일 간격은 GitHub Actions 지연(수 시간)과 겹치면 실제 간격이 7일을 초과할 수 있음

## 필요한 추가 설정

GitHub Secrets에 2개 추가 필요:

| 키 | 값 |
|----|----|
| `NEXT_PUBLIC_SITE_URL` | Vercel 배포 URL |
| `PING_SECRET` | `openssl rand -base64 32` 결과값 |

Vercel 환경변수에도 `PING_SECRET` 동일값 추가 필요.

Closes #215