### PR TITLE
fix: replace /health with /rest/v1/ for keep-alive health check #216

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -11,8 +11,10 @@ jobs:
     steps:
       - name: Check Supabase health
         run: |
-          STATUS=$(curl -sf -o /dev/null -w "%{http_code}" \
-            "${{ secrets.SUPABASE_URL }}/health")
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "apikey: ${{ secrets.SUPABASE_SECRET_KEY }}" \
+            -H "Authorization: Bearer ${{ secrets.SUPABASE_SECRET_KEY }}" \
+            "${{ secrets.SUPABASE_URL }}/rest/v1/")
           echo "HTTP status: $STATUS"
           if [ "$STATUS" != "200" ]; then
             echo "Supabase health check FAILED (status: $STATUS)"


### PR DESCRIPTION
## 원인

`/health` 엔드포인트가 Supabase 프로젝트에 존재하지 않아 404를 반환했고,
curl `-f` 플래그 + bash `-e` 조합으로 exit code 22가 발생해 워크플로 전체가 실패했다.

## 변경 사항

| 항목 | 변경 전 | 변경 후 |
|------|---------|---------|
| 엔드포인트 | `SUPABASE_URL/health` | `SUPABASE_URL/rest/v1/` |
| 인증 | 없음 | `apikey` + `Authorization` 헤더 |
| curl 플래그 | `-sf` | `-s` (HTTP 상태 코드를 직접 비교) |

Closes #216