### PR TITLE
fix: keep-alive 워크플로 통합 및 실제 DB 쿼리로 수정 #216

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -11,10 +11,13 @@ jobs:
     steps:
       - name: Check Supabase health
         run: |
+          URL=$(echo -n "${{ secrets.SUPABASE_URL }}" | tr -d '[:space:]')
+          URL=${URL%/}
+          echo "Target host: $(echo "$URL" | sed -E 's#https?://([^/]+).*#\1#')"
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
             -H "apikey: ${{ secrets.SUPABASE_SECRET_KEY }}" \
             -H "Authorization: Bearer ${{ secrets.SUPABASE_SECRET_KEY }}" \
-            "${{ secrets.SUPABASE_URL }}/rest/v1/")
+            "${URL}/rest/v1/")
           echo "HTTP status: $STATUS"
           if [ "$STATUS" != "200" ]; then
             echo "Supabase health check FAILED (status: $STATUS)"
@@ -24,7 +27,9 @@ jobs:
 
       - name: Ping via app
         run: |
+          SITE_URL=$(echo -n "${{ secrets.NEXT_PUBLIC_SITE_URL }}" | tr -d '[:space:]')
+          SITE_URL=${SITE_URL%/}
           curl -fsS \
             -H "x-ping-secret: ${{ secrets.PING_SECRET }}" \
-            "${{ secrets.NEXT_PUBLIC_SITE_URL }}/api/ping" \
+            "${SITE_URL}/api/ping" \
             && echo "Supabase ping OK"

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -2,14 +2,17 @@ name: Supabase Keep Alive
 
 on:
   schedule:
-    - cron: '0 1 */3 * *' # 3일마다 10:00 KST (UTC 01:00)
+    - cron: '0 1 */2 * *' # 2일마다 10:00 KST (UTC 01:00)
   workflow_dispatch:
 
 jobs:
   ping:
     runs-on: ubuntu-latest
     steps:
-      - name: Check Supabase health
+      # users 테이블을 직접 조회해 실제 DB 활동을 발생시킨다.
+      # /rest/v1/ 루트나 /health 는 게이트웨이만 응답하고 Postgres 를 깨우지
+      # 못할 수 있으므로, 실제 테이블 쿼리 하나로 keep-alive 와 헬스 체크를 겸한다.
+      - name: Keep Supabase alive
         run: |
           URL=$(echo -n "${{ secrets.SUPABASE_URL }}" | tr -d '[:space:]')
           URL=${URL%/}
@@ -17,19 +20,10 @@ jobs:
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
             -H "apikey: ${{ secrets.SUPABASE_SECRET_KEY }}" \
             -H "Authorization: Bearer ${{ secrets.SUPABASE_SECRET_KEY }}" \
-            "${URL}/rest/v1/")
+            "${URL}/rest/v1/users?select=count&limit=1")
           echo "HTTP status: $STATUS"
           if [ "$STATUS" != "200" ]; then
-            echo "Supabase health check FAILED (status: $STATUS)"
+            echo "Supabase keep-alive FAILED (status: $STATUS)"
             exit 1
           fi
-          echo "Supabase is healthy"
-
-      - name: Ping via app
-        run: |
-          SITE_URL=$(echo -n "${{ secrets.NEXT_PUBLIC_SITE_URL }}" | tr -d '[:space:]')
-          SITE_URL=${SITE_URL%/}
-          curl -fsS \
-            -H "x-ping-secret: ${{ secrets.PING_SECRET }}" \
-            "${SITE_URL}/api/ping" \
-            && echo "Supabase ping OK"
+          echo "Supabase is alive"


### PR DESCRIPTION
## 문제

Supabase Keep Alive 워크플로가 06-13부터 연속 실패(exit 6, NXDOMAIN). 프로젝트가 일시정지되면서 도메인이 내려간 상태였음.

근본 원인:
- main 버전이 `/health` 엔드포인트를 사용 — 게이트웨이만 응답하고 Postgres를 실제로 깨우지 못함
- `set -e`로 인해 health 체크 스텝이 실패하면 진짜 keep-alive 쿼리(`/api/ping`)에 도달하지 못함
- 결과적으로 실제 DB 활동이 발생하지 않아 7일 미사용 정지에 취약

## 변경

- 2개 스텝(`/health` 체크 + 앱 ping)을 **users 테이블 직접 쿼리 1개**로 통합 → 실제 DB 활동 보장, Vercel 배포 의존 제거
- URL 시크릿의 공백/줄바꿈 trim + 끝 슬래시 제거
- 진단용 `Target host` 출력 추가
- 스케줄 3일 → 2일로 단축(여유 마진)

## 검증

브랜치에서 수동 실행 → success (`HTTP status: 200`, `Supabase is alive`)

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)